### PR TITLE
Introduce code owners for stricter review process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+
+
+# See https://help.github.com/articles/about-codeowners/
+
+* @kinueng @steven1046 @lauracowen @mbroz2


### PR DESCRIPTION
We are close to delivering the capability to make a openliberty.io blog preview cards link to an external URLs.  I do not want people to use this capability without having a strict review process in place.

I have turned on requiring a review from code owners set by this PR.