### PR TITLE
Use OpenLiberty GitHub organization icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Create a pull request with the content of the blog post placed in the `drafts` f
 - title: `title of the blog post`
 - categories: blog
 - author_picture: `secure url to author picture`
-     - If a picture cannot be found, the openliberty.io logo can be used instead https://openliberty.io/favicon.ico
+     - If a picture cannot be found, the openliberty.io logo can be used instead https://avatars3.githubusercontent.com/u/28316667
 - blog_description: `Description of blog post used in the preview card on openliberty.io/blog`
      - Please keep your `blog_description` to around 60 words
 - seo-title: `Blog Title used in search results and on social media - OpenLiberty.io`

--- a/drafts/blog_draft.adoc
+++ b/drafts/blog_draft.adoc
@@ -3,7 +3,7 @@ layout: post
 title: Post title here.
 date:   2018-06-08 11:30:00 -0000
 categories: blog
-author_picture: https://openliberty.io/favicon.ico
+author_picture: https://avatars3.githubusercontent.com/u/28316667
 seo-title: Title here - OpenLiberty.io. Used in search results and on social media.
 seo-description: Active description of the post - 50–300 characters. This is used in search results and on social media.
 blog_description: "Blog preview description. ~60 words - this is used in the preview card on openliberty.io/blog"

--- a/publish/2018-11-09-prevent-message-log-rotating.adoc
+++ b/publish/2018-11-09-prevent-message-log-rotating.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Maximise log history on Open Liberty in production
 categories: blog
-author_picture: https://openliberty.io/favicon.ico
+author_picture: https://avatars3.githubusercontent.com/u/28316667
 seo-title: Maximise log history on Open Liberty in production - OpenLiberty.io.
 seo-description: In development, starting a new log file each time the server restarts is great but, in production, you can now disable this behaviour so that you can retain more history in your logs.
 blog_description: "In development, starting a new log file each time the server restarts is great but, in production, you can now disable this behaviour so that you can retain more history in your logs."


### PR DESCRIPTION
I made a silly assumption that I can use the `favicon.ico` as a quick fix.  It oddly worked locally, but I cannot get the favicon to work anymore.  Regardless, it was a bad choice by me so let's use the logo of our OpenLiberty GitHub organization.