### PR TITLE
adding shared lib option

### DIFF
--- a/publish/2019-02-19-mongodb-with-open-liberty.adoc
+++ b/publish/2019-02-19-mongodb-with-open-liberty.adoc
@@ -146,7 +146,7 @@ Previously, using MongoDB required enabling the `mongodb-2.0` feature, which was
 MongoDB 2.X versions. By using a CDI producer, any version of MongoDB can be used, with no need for a specific MongoDB feature. Even if the MongoDB Java Driver API changes, simple updates to your CDI producer will allow it to continue to work.
 You should remove the `mongodb-2.0` feature from your `server.xml` when using newer versions of MongoDB with a CDI producer.
 
-The MongoDB driver needs to be bundled in your application. To do this with Maven you can use a dependency:
+The MongoDB driver should be bundled in your application. To do this with Maven you can use a dependency:
 
 [source, xml]
 ----
@@ -155,6 +155,23 @@ The MongoDB driver needs to be bundled in your application. To do this with Mave
     <artifactId>mongo-java-driver</artifactId>
     <version>X.X.X</version>
 </dependency>
+----
+
+If you have multiple applications accessing MongoDB, instead of bundling the MongoDB driver,
+ you can configure a shared library in your `server.xml` like this:
+[source, xml]
+----
+<library id="MongoLib">
+    <file name="${shared.resource.dir}/mongo-java-driver-3.8.0.jar" />
+</library>
+
+<webApplication location="MongoDBSample1.war">
+    <classloader commonLibraryRef="MongoLib" />
+</webApplication>
+
+<webApplication location="MongoDBSample2.war">
+    <classloader commonLibraryRef="MongoLib" />
+</webApplication>
 ----
 
 This illustrates how easy it is to create a CDI producer for MongoDB, configure it with MicroProfile Config, 


### PR DESCRIPTION
Adding shared library option to MongoDB guide. Updated 'No need for a MongoDB feature' section below:

![image](https://user-images.githubusercontent.com/21284019/53045661-cf846100-3453-11e9-9781-c244f2fc849b.png)

