### PR TITLE
Cleanup roles information for test connection blog post.

### DIFF
--- a/publish/2019-09-13-testing-database-connections-REST-APIs.adoc
+++ b/publish/2019-09-13-testing-database-connections-REST-APIs.adoc
@@ -26,7 +26,7 @@ Both the validation and config endpoints are generated using a combination of th
 
 <<openapi, OpenAPI documents>> on these endpoints become available when a MicroProfile OpenAPI feature is enabled.
 
-*A note on security:* Access to these endpoints requires authentication with the Liberty server. The config endpoint requires a minimum of `reader-role` access and the validation endpoint requires `administrator-role` access. The examples we will be walking through use either `quickStartSecurity` or `basicRegistry` with the `appSecurity-2.0` feature to setup secure access. However, any Liberty supported user registry will work. 
+*A note on security:* Access to these endpoints requires authenticating as a user with the `administrator-role` role. The examples we will be walking through use either `quickStartSecurity` or `basicRegistry` with the `appSecurity-2.0` feature to setup secure access. However, any Liberty supported user registry will work. 
 
 Now, let’s take a look at how you can use this new REST API to validate your configuration.
 
@@ -1312,15 +1312,11 @@ Here is a sample `server.xml` configuration that uses the Configuration Validato
   
   <basicRegistry>
     <user name="blogAdmin" password="blogAdminPwd" />
-    <user name="blogReader" password="blogReaderPwd" />
     <user name="blogUser" password="blogUserPwd" />
   </basicRegistry>
   <administrator-role>
     <user>blogAdmin</user>
   </administrator-role>
-  <reader-role>
-    <user>blogReader</user>
-  </reader-role>
 
   <authData id="auth2" user="containerAuthUser2" password="2containerAuthUser"/>
 
@@ -1431,15 +1427,11 @@ Let's use the following server config snippets:
   
   <basicRegistry>
     <user name="blogAdmin" password="blogAdminPwd" />
-    <user name="blogReader" password="blogReaderPwd" />
     <user name="blogUser" password="blogUserPwd" />
   </basicRegistry>
   <administrator-role>
     <user>blogAdmin</user>
   </administrator-role>
-  <reader-role>
-    <user>blogReader</user>
-  </reader-role>
 
   <library id="CloudantLib">
     <fileset dir="${server.config.dir}/cloudant"/>


### PR DESCRIPTION
This PR will need to be reverted when the `reader-role` function moves out of Beta.
The revert command will be `git revert d89156710c6c2203fbc44a2df466c377379725a2`