### PR TITLE
Update LMP version description, add guide links

### DIFF
--- a/publish/2019-10-22-liberty-dev-mode.adoc
+++ b/publish/2019-10-22-liberty-dev-mode.adoc
@@ -23,7 +23,7 @@ You can also follow the steps in the https://github.com/OpenLiberty/demo-devmode
 
 == Setting up the project
 
-For Maven projects, dev mode is run through the Liberty Maven Plugin.  Specify the latest version of the Liberty Maven Plugin in your project's `pom.xml` file.  Note that in versions 3.0 and above, the `groupId` of the plugin is `io.openliberty.tools`.
+For Maven projects, dev mode is run through the Liberty Maven Plugin.  Specify the Liberty Maven Plugin with version `3.1` or above in your project’s `pom.xml` file.
 [source,xml]
 ----
     <plugin>
@@ -57,4 +57,9 @@ You can quit dev mode at any time by pressing CTRL+C in the terminal, or type `q
 
 == Further reading
 
-For more details on how to use dev mode, see the documentation for the https://github.com/OpenLiberty/ci.maven/blob/master/docs/dev.md#dev[dev goal of the Liberty Maven Plugin].
+For more details on dev mode, see the documentation for the https://github.com/OpenLiberty/ci.maven/blob/master/docs/dev.md#dev[dev goal of the Liberty Maven Plugin].
+
+You can also check out some of the guides to get started with using dev mode to develop an application:
+
+* link:/guides/getting-started.html[Packaging and deploying applications]
+* link:/guides/rest-intro.html[Creating a RESTful web service]


### PR DESCRIPTION
- Simplified the description for the Liberty Maven Plugin to say version 3.1 or above.
- Updated the Further reading section with links to guides for using dev mode.