### PR TITLE
Set OL.io relative links to use an attribute so they can be prefixed by RH build

### DIFF
--- a/publish/2020-01-17-openshift-oauth-server-social-login-liberty-20001.adoc
+++ b/publish/2020-01-17-openshift-oauth-server-social-login-liberty-20001.adoc
@@ -11,11 +11,12 @@ blog_description: In Open Liberty 20.0.0.1, you can configure the Social Login f
 = Use Red Hat OpenShift\'s built-in OAuth server as an authentication provider in Open Liberty 20.0.0.1
 Tom Jennings <https://github.com/tomjenningss>
 :imagesdir: /
+:url-prefix:
 
 // tag::intro[]
 In Open Liberty 20.0.0.1, you can configure the Social Login feature to use Red Hat OpenShift's OAuth server for authentication. In addition, there is a new MicroProfile Metric to measure CPU time, memory heap and response time.  
 
-Give it a try in link:/about/[Open Liberty] 20.0.0.1
+Give it a try in link:{url-prefix}/about/[Open Liberty] 20.0.0.1
 
 In Open Liberty 20.0.0.1:
 
@@ -36,7 +37,7 @@ If you're interested in what's coming soon in Open Liberty, take a look at our <
 
 == Run your apps using 20.0.0.1
 
-If you're using link:/guides/maven-intro.html[Maven], here are the coordinates:
+If you're using link:{url-prefix}/guides/maven-intro.html[Maven], here are the coordinates:
 
 [source,xml]
 ----
@@ -48,7 +49,7 @@ If you're using link:/guides/maven-intro.html[Maven], here are the coordinates:
 </dependency>
 ----
 
-Or for link:/guides/gradle-intro.html[Gradle]:
+Or for link:{url-prefix}/guides/gradle-intro.html[Gradle]:
 
 [source,gradle]
 ----
@@ -65,7 +66,7 @@ docker pull open-liberty
 ----
 //end::run[]
 
-Or take a look at our link:/downloads/[Downloads page].
+Or take a look at our link:{url-prefix}/downloads/[Downloads page].
 
 [link=https://stackoverflow.com/tags/open-liberty]
 image::img/blog/blog_btn_stack.svg[Ask a question on Stack Overflow, align="center"]
@@ -170,6 +171,7 @@ The new `processCpuTime` metric is displayed on the `/metrics` endpoint with the
 The following images show that the old metric, `processCpuLoad`, plateaus at 12.5% (4/23), while the new metric, `processCpuTime`, more accurately represents the percentage of CPU used.
 
 image::img/blog/20001-highcpuload.png[align="center"]
+
 image::img/blog/20001-lowcpuload.png[align="center"]
 
 
@@ -204,7 +206,7 @@ To use the JSF 2.3, enable the `jsf-2.3` feature to leverage the latest Apache M
 [#previews]
 == Previews of early implementations available in development builds
 
-You can now also try out early implementations of some new capabilities in the link:https://openliberty.io/downloads/#development_builds[latest Open Liberty development builds]:
+You can now also try out early implementations of some new capabilities in the link:{url-prefix}/downloads/#development_builds[latest Open Liberty development builds]:
 
 * <<acr, Automatically compress HTTP responses>>
 
@@ -241,9 +243,9 @@ image::img/blog/20001-http-response-compression-diagram.png[align="center"]
 
 [#GraphQL]
 == You are now free to use GraphQL with Open Liberty! 
-In our latest OpenLiberty development builds, users can now develop and deploy GraphQL applications.  GraphQL is a complement/alternative to REST that allows clients to fetch or modify remote data, but with fewer round-trips.  Liberty now supports the (still under development) MicroProfile GraphQL APIs (https://github.com/eclipse/microprofile-graphql[learn more]) that allow developers to create GraphQL apps using simple annotations - similar to how JAX-RS uses annotations to create a RESTful app.
+In our latest OpenLiberty development builds, users can now develop and deploy GraphQL applications.  GraphQL is a complement/alternative to REST that allows clients to fetch or modify remote data, but with fewer round-trips.  Liberty now supports the (still under development) MicroProfile GraphQL APIs (link:https://github.com/eclipse/microprofile-graphql[learn more]) that allow developers to create GraphQL apps using simple annotations - similar to how JAX-RS uses annotations to create a RESTful app.
 
-Developing and deploying a GraphQL app is cinch - take a look at this https://github.com/OpenLiberty/sample-mp-graphql[sample] to get started with these powerful APIs!
+Developing and deploying a GraphQL app is cinch - take a look at this link:https://github.com/OpenLiberty/sample-mp-graphql[sample] to get started with these powerful APIs!
 
 
 == Get Liberty 20.0.0.1 now


### PR DESCRIPTION
Tested locally in Docker image and it works for the OL.io site (ie no behaviour change with the changes in this file).

Just need RH to say that they can override the attribute for their own build of the same file.