### PR TITLE
Syntaxerrors

### DIFF
--- a/publish/2018-12-20-http-forwarded-header.adoc
+++ b/publish/2018-12-20-http-forwarded-header.adoc
@@ -59,7 +59,7 @@ Using a common `remoteIp`:
 ----
 
 
-=== Stuff you might need to know
+== Stuff you might need to know
 
 Any of the servlet features supported by Liberty can be configured to retrieve the remote client IP, the host and/or the request protocol. The ServletRequest Java API methods that will retrieve the remote client endpoint information if the Forwarded and X-Forwarded-* header support feature is enabled and HTTP Channel verification succeed are: `getRemoteAddr()`, `getRemoteHost()`, `getRemotePort()` , `getScheme()`, `isSecure()`.
 
@@ -75,7 +75,7 @@ When `useRemoteIpInAccessLog` is set to `true`, the NCSA Access Log (if configur
 
 //
 
-## Ready to give it a try?
+== Ready to give it a try?
 
 Take a look at https://openliberty.io/downloads[Open Liberty 19.0.0.1] on our Downloads page.
 

--- a/publish/2019-05-08-jakarta-ee-naming.adoc
+++ b/publish/2019-05-08-jakarta-ee-naming.adoc
@@ -21,10 +21,10 @@ The question for the community is "how we should move forward from here?" It see
 
 Jakarta EE will only succeed if developers have a seamless transition from Java EE to Jakarta EE. I think there are four aspects to pulling off zero migration with a rename:
 
-1. Existing application binaries need to continue to work without change.
-1. Existing application source needs to continue to work without change.
-1. Tools must be provided to quickly and easily change the import statements for Java source.
-1. Applications that are making use of the new APIs must be able to call binaries that have not been updated.
+. Existing application binaries need to continue to work without change.
+. Existing application source needs to continue to work without change.
+. Tools must be provided to quickly and easily change the import statements for Java source.
+. Applications that are making use of the new APIs must be able to call binaries that have not been updated.
 
 The first two are trivial to do: Java class files have a constant pool that contains all the referenced class and method references. Updating the constant pool when the class is loaded will be technically easy, cheap at runtime, and safe. We are literally talking about changing `javax.servlet` to `jakarta.servlet`, no method changes.
 

--- a/publish/2019-09-13-microprofile-reactive-messaging.adoc
+++ b/publish/2019-09-13-microprofile-reactive-messaging.adoc
@@ -237,8 +237,8 @@ This default ensures that all messages are acknowledged, however acknowledging m
 
 To ensure that messages are not lost, you must:
 
-1. https://download.eclipse.org/microprofile/microprofile-reactive-messaging-1.0/microprofile-reactive-messaging-spec.html#_message_acknowledgement[Check the specification] to see whether reactive messaging does message acknowledgements before (pre-process) or after (post-process) the message processing, for your methods.
-1. If it does pre-processing, either:
+. https://download.eclipse.org/microprofile/microprofile-reactive-messaging-1.0/microprofile-reactive-messaging-spec.html#_message_acknowledgement[Check the specification] to see whether reactive messaging does message acknowledgements before (pre-process) or after (post-process) the message processing, for your methods.
+. If it does pre-processing, either:
   * change your method signature so that it does post-processing
   * use manual acknowledgement instead
 
@@ -246,9 +246,9 @@ To ensure that messages are not lost, you must:
 
 To use manual acknowledgement, you must do three things:
 
-1. Annotate the method with `@Acknowledgement(MANUAL)`
-2. Use a method signature which includes the `Message`
-3. Call `Message.ack()` on each incoming message when the processing of that message has completed.
+. Annotate the method with `@Acknowledgement(MANUAL)`
+. Use a method signature which includes the `Message`
+. Call `Message.ack()` on each incoming message when the processing of that message has completed.
 
 Here's an example processing method which accepts strings and filters out any strings which are three characters or fewer.
 


### PR DESCRIPTION
Fixed syntax warnings that appeared in published posts in the build. Tested the fixes and they don't alter the output.