### PR TITLE
Add tags for latest 2 blogs

### DIFF
--- a/blog_tags.json
+++ b/blog_tags.json
@@ -44,7 +44,7 @@
         },
         {
             "name": "metrics",
-            "posts": ["microprofile-30-developer-experience","microprofile-metrics-migration","microprofile-faulttolerance-1.1-metrics","get-more-metrics-microprofile20","configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", "openshift-oauth-server-social-login-liberty-20001", "modernizing-javaee-cloud-native-open-liberty", "microprofile-32-health-metrics-190012"]
+            "posts": ["alerts-slack-prometheus-alertmanager-open-liberty","Kibana-dashboard-visualizations","microprofile-30-developer-experience","microprofile-metrics-migration","microprofile-faulttolerance-1.1-metrics","get-more-metrics-microprofile20","configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", "openshift-oauth-server-social-login-liberty-20001", "modernizing-javaee-cloud-native-open-liberty", "microprofile-32-health-metrics-190012"]
         },
         {
             "name": "Jakarta EE",
@@ -73,7 +73,7 @@
         },
         {
             "name": "monitoring and diagnosis",
-            "posts": ["custom-fields-json-logs", "diagnose-slow-requests-easily-190011", "configure-logs-JSON-format-190010"]
+            "posts": ["alerts-slack-prometheus-alertmanager-open-liberty","Kibana-dashboard-visualizations","custom-fields-json-logs", "diagnose-slow-requests-easily-190011", "configure-logs-JSON-format-190010"]
         },
         {
             "name": "performance enhancements",


### PR DESCRIPTION
Add 'metrics' and 'monitoring and diagnosis' tags for alerts-slack-prometheus-alertmanager-open-liberty and Kibana-dashboard-visualizations blogs