### PR TITLE
Update link to mp starter extension

### DIFF
--- a/publish/2019-10-17-dev-mode-developer-experience.adoc
+++ b/publish/2019-10-17-dev-mode-developer-experience.adoc
@@ -63,7 +63,7 @@ As an aside, MicroShed - what is it?
 
 MicroShed is a new GitHub organization where we are collaborating with the community on developer tools for building Java microservices.
 For instance, we worked with the MicroProfile community to build a
-https://marketplace.visualstudio.com/items?itemName=MicroShed.mp-starter-vscode-ext[VS Code extension for MicroProfile Starter].
+https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.mp-starter-vscode-ext[VS Code extension for MicroProfile Starter].
 It is an open community for collaboration. Everybody is welcome so join us there!
 
 == Let us know what you think


### PR DESCRIPTION
The old link (https://marketplace.visualstudio.com/items?itemName=MicroShed.mp-starter-vscode-ext) in the blog is deprecated, replace with the new link: https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.mp-starter-vscode-ext