### PR TITLE
Fix prefix for reactive messaging config

### DIFF
--- a/publish/2020-03-13-access-specific-kafka-properties-samesite-20003.adoc
+++ b/publish/2020-03-13-access-specific-kafka-properties-samesite-20003.adoc
@@ -118,8 +118,8 @@ MicroProfile Config Properties
 
 [source, java]
 ----
-mp.reactive.messaging.outgoing.channel3.connector=liberty-kafka
-mp.reactive.messaging.outgoing.channel3.topic=myOtherTopic #Overrides value in code
+mp.messaging.outgoing.channel3.connector=liberty-kafka
+mp.messaging.outgoing.channel3.topic=myOtherTopic #Overrides value in code
 ----
 Reactive Messaging Bean
 


### PR DESCRIPTION
Correct format is
mp.messaging.[incoming|outgoing].[channel].[attribute]=[value]