### PR TITLE
`jaxrsMonitor-1.0` feature should be `jaxrs-2.1`

### DIFF
--- a/drafts/2020-04-09-release-20004.adoc
+++ b/drafts/2020-04-09-release-20004.adoc
@@ -127,7 +127,7 @@ MicroProfile Metrics 2.3 introduces a new metric type called a Simple Timer (ann
 
 The new Simple Timer metric is a light-weight alternative to the existing Timer metric. It only tracks the total timing duration and counts the amount of times it was invoked. The Timer metric on the other hand is a performance heavy metric that continually calculates duration statistics and throughput statistics resulting in 14 values.
 
-The new REST stat metrics are gathered from REST resource method usage (i.e `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`, `PATCH`, `HEAD`). Total time duration and total count of invocation is tracked ( by use of the Simple Timer metric). This functionality is properly enabled when used in combination with the `jaxrsMonitor-1.0` feature. All REST stat metrics will use the `REST.request` metric name and will be tagged/labeled with their fully qualified class name and method signature.
+The new REST stat metrics are gathered from REST resource method usage (i.e `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`, `PATCH`, `HEAD`). Total time duration and total count of invocation is tracked ( by use of the Simple Timer metric). This functionality is properly enabled when used in combination with the `jaxrs-2.1` feature. All REST stat metrics will use the `REST.request` metric name and will be tagged/labeled with their fully qualified class name and method signature.
 
 To enable the feature, include the following in the `server.xml`.
 


### PR DESCRIPTION
The `jaxrsMonitor-1.0` feature was a temporary feature 
only used in beta to work around beta-related build tooling 
issues.  In GA, the metrics are enabled by auto-feature - 
so users only need to enable `mpMetrics-2.3` and 
`jaxrs-2.1` to get the REST stats.