### PR TITLE
Non-validating XML syntax and typo

### DIFF
--- a/publish/2020-04-22-http-response-compression.adoc
+++ b/publish/2020-04-22-http-response-compression.adoc
@@ -86,7 +86,10 @@ Configuring compression for individual HTTP endpoints:
 <httpEndpoint id="defaultHttpEndpoint"
                         httpPort="9080"
                         httpsPort="9443">
-    <compression serverPreferredAlgorithm="deflate|gzip|x-gzip|zlib|identity|none>" types="+application/*, -text/plain"/>
+    <compression serverPreferredAlgorithm="deflate|gzip|x-gzip|zlib|identity|none">
+          <types>+application/*</types>
+          <types>-text/plain</types>
+    </compression>
 </httpEndpoint>
 ----
 
@@ -106,7 +109,10 @@ Configuring compression for all HTTP endpoints:
                         compressionRef="myCompressionID">
     </httpEndpoint>
 
-    <compression id="myCompressionID" serverPreferredAlgorithm="deflate|gzip|x-gzip|zlib|identity|none>" types="+application/*, -text/plain"/>
+    <compression id="myCompressionID" serverPreferredAlgorithm="deflate|gzip|x-gzip|zlib|identity|none">
+              <types>+application/*</types>
+              <types>-text/plain</types>
+    </compression>
 ----
 The `types` attribute in the examples adds all application content types and removes the `text/plain` content type from the `text/*` default.
 


### PR DESCRIPTION
@NottyCode Does this updated syntax look right now?
@mrsaldana See my slack message but basically:

Using types as an attribute won’t validate against the server.xml schema; it should be enumerated nested elements. It matters because although it will run at runtime, it won’t validate in the tools (IDE or Admin Center). We shouldn't doc non-validating examples.