### PR TITLE
Add blog tags for 20.0.0.5 release announcement

### DIFF
--- a/blog_tags.json
+++ b/blog_tags.json
@@ -11,12 +11,12 @@
         },
         {
             "name": "announcements",
-            "posts": ["open-sourcing-liberty", "javaone-sessions-open-liberty-team", "microprofile-12-open-liberty-17003", "jsf-implementation-open-liberty-17004", "full_java_ee_8_liberty_18002", "meet-us-at-oc1-and-ece", "REST-Liberty-reactive-2018", "new-4-weekly-release-schedule", "open-liberty-19001", "java-11", "devnexus-microprofile-open-liberty", "java11-hotspot-19005", "microprofile-rest-client-19006", "microprofile-30-developer-experience", "microprofile-context-propagation-19008", "microprofile-reactive-messaging-19009","configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", "liberty-dev-mode-vscode", "openshift-oauth-server-social-login-liberty-20001", "preview-microprofile-3-3-20002", "access-specific-kafka-properties-samesite-20003", "microprofile-3-3-open-liberty-20004"],
+            "posts": ["open-sourcing-liberty", "javaone-sessions-open-liberty-team", "microprofile-12-open-liberty-17003", "jsf-implementation-open-liberty-17004", "full_java_ee_8_liberty_18002", "meet-us-at-oc1-and-ece", "REST-Liberty-reactive-2018", "new-4-weekly-release-schedule", "open-liberty-19001", "java-11", "devnexus-microprofile-open-liberty", "java11-hotspot-19005", "microprofile-rest-client-19006", "microprofile-30-developer-experience", "microprofile-context-propagation-19008", "microprofile-reactive-messaging-19009","configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", "liberty-dev-mode-vscode", "openshift-oauth-server-social-login-liberty-20001", "preview-microprofile-3-3-20002", "access-specific-kafka-properties-samesite-20003", "microprofile-3-3-open-liberty-20004", "2020-05-07-EJB-persistent-timers-20005"],
             "featured": "true"
         },
         {
             "name": "release",
-            "posts": ["jsf-implementation-open-liberty-17004", "distributed-tracing-microservices-18001", "full_java_ee_8_liberty_18002", "get-more-metrics-microprofile20", "microprofile21-18004", "new-4-weekly-release-schedule", "open-liberty-19001", "sharding-keys-jdbc43-19002", "microprofile22-liberty-19003", "reactive-microservices-microprofile-19004", "java11-hotspot-19005", "microprofile-rest-client-19006", "microprofile-30-developer-experience", "microprofile-context-propagation-19008", "microprofile-reactive-messaging-19009", "configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", "microprofile-32-health-metrics-190012", "openshift-oauth-server-social-login-liberty-20001", "preview-microprofile-3-3-20002", "access-specific-kafka-properties-samesite-20003", "microprofile-3-3-open-liberty-20004"]
+            "posts": ["jsf-implementation-open-liberty-17004", "distributed-tracing-microservices-18001", "full_java_ee_8_liberty_18002", "get-more-metrics-microprofile20", "microprofile21-18004", "new-4-weekly-release-schedule", "open-liberty-19001", "sharding-keys-jdbc43-19002", "microprofile22-liberty-19003", "reactive-microservices-microprofile-19004", "java11-hotspot-19005", "microprofile-rest-client-19006", "microprofile-30-developer-experience", "microprofile-context-propagation-19008", "microprofile-reactive-messaging-19009", "configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", "microprofile-32-health-metrics-190012", "openshift-oauth-server-social-login-liberty-20001", "preview-microprofile-3-3-20002", "access-specific-kafka-properties-samesite-20003", "microprofile-3-3-open-liberty-20004", "2020-05-07-EJB-persistent-timers-20005"]
         },
         {
             "name": "Maven",
@@ -24,7 +24,7 @@
         },
         {
             "name": "security",
-            "posts": ["sharding-keys-jdbc43-19002", "microprofile-rest-client-19006","testing-database-connections-REST-APIs", "microprofile-32-health-metrics-190012", "access-specific-kafka-properties-samesite-20003", "set-samesite-attribute-cookies-liberty"]
+            "posts": ["sharding-keys-jdbc43-19002", "microprofile-rest-client-19006","testing-database-connections-REST-APIs", "microprofile-32-health-metrics-190012", "access-specific-kafka-properties-samesite-20003", "set-samesite-attribute-cookies-liberty", "2020-05-07-EJB-persistent-timers-20005"]
         },
         {
             "name": "Spring",
@@ -73,7 +73,7 @@
         },
         {
             "name": "monitoring",
-            "posts": ["alerts-slack-prometheus-alertmanager-open-liberty","Kibana-dashboard-visualizations","custom-fields-json-logs", "diagnose-slow-requests-easily-190011", "configure-logs-JSON-format-190010", "prometheus-alertmanager-rhocp-open-liberty", "microprofile-3-3-open-liberty-20004"]
+            "posts": ["alerts-slack-prometheus-alertmanager-open-liberty","Kibana-dashboard-visualizations","custom-fields-json-logs", "diagnose-slow-requests-easily-190011", "configure-logs-JSON-format-190010", "prometheus-alertmanager-rhocp-open-liberty", "microprofile-3-3-open-liberty-20004", "2020-05-07-EJB-persistent-timers-20005"]
         },
         {
             "name": "performance enhancements",


### PR DESCRIPTION
I don't believe we currently have a good tag that matches the "EJB persistent timers coordination and failover across members" section.