### PR TITLE
(Tags) Organize posts 2 per line and reverse order

### DIFF
--- a/blog_tags.json
+++ b/blog_tags.json
@@ -2,53 +2,119 @@
     "blog_tags": [
         {
             "name": "MicroProfile",
-            "posts": ["microprofile-12-open-liberty-17003", "mpRestClient", "distributed-tracing-microservices-18001", "microprofile-openapi-intro", "java-microservices-microprofile", "whats-next-microprofile-jakartaee", "dynamic-update-microservice-config", "get-more-metrics-microprofile20", "microprofile-faulttolerance-1.1-metrics", "MicroProfile-Natural-Evolution-for-Microservices-Development", "distributed-tracing-microservices", "microprofile21-18004", "async-rest-jaxrs-microprofile", "mongodb-with-open-liberty", "microprofile-concurrency", "integration-testing-with-testcontainers", "developer-experience-microprofile-rest-client", "microprofile22-liberty-19003", "reactive-microservices-microprofile-19004", "java11-hotspot-19005", "microprofile-rest-client-19006","microprofile-30-developer-experience","microprofile-metrics-migration", "microprofile-context-propagation-19008", "microprofile-reactive-messaging-19009", "microprofile-context-propagation", "configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", "microprofile-reactive-messaging", "java-microprofile-jwt-okta", "production-experience-open-liberty", "openshift-oauth-server-social-login-liberty-20001", "modernizing-javaee-cloud-native-open-liberty", "microprofile-32-health-metrics-190012", "preview-microprofile-3-3-20002", "introduction-to-open-liberty", "generate-microprofile-rest-client-code", "microprofile-3-3-open-liberty-20004", "fast-setup-java-microservice-microprofile-starter"],
+            "posts": ["microprofile-12-open-liberty-17003", "mpRestClient", 
+                      "distributed-tracing-microservices-18001", "microprofile-openapi-intro", 
+                      "java-microservices-microprofile", "whats-next-microprofile-jakartaee", 
+                      "dynamic-update-microservice-config", "get-more-metrics-microprofile20", 
+                      "microprofile-faulttolerance-1.1-metrics", "distributed-tracing-microservices", 
+                       "MicroProfile-Natural-Evolution-for-Microservices-Development", "microprofile21-18004", 
+                      "async-rest-jaxrs-microprofile", "mongodb-with-open-liberty", 
+                      "microprofile-concurrency", "integration-testing-with-testcontainers", 
+                      "developer-experience-microprofile-rest-client", "microprofile22-liberty-19003", 
+                      "reactive-microservices-microprofile-19004", "java11-hotspot-19005", 
+                      "microprofile-rest-client-19006","microprofile-30-developer-experience", 
+                      "microprofile-metrics-migration", "microprofile-context-propagation-19008", 
+                      "microprofile-reactive-messaging-19009", "microprofile-context-propagation", 
+                      "configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", 
+                      "microprofile-reactive-messaging", "java-microprofile-jwt-okta", 
+                      "production-experience-open-liberty", "openshift-oauth-server-social-login-liberty-20001", 
+                      "modernizing-javaee-cloud-native-open-liberty", "microprofile-32-health-metrics-190012", 
+                      "preview-microprofile-3-3-20002", "introduction-to-open-liberty", 
+                      "generate-microprofile-rest-client-code", "microprofile-3-3-open-liberty-20004", 
+                      "fast-setup-java-microservice-microprofile-starter"],
             "featured": "true"
         },
         {
             "name": "Java EE",
-            "posts": ["full_java_ee_8_liberty_18002", "whats-next-microprofile-jakartaee", "REST-Liberty-reactive-2018", "async-rest-jaxrs-microprofile", "sharding-keys-jdbc43-19002", "integration-testing-with-testcontainers", "microprofile22-liberty-19003", "jaxrs-reactive-extensions", "jakarta-ee-naming", "java11-hotspot-19005", "production-experience-open-liberty", "modernizing-javaee-cloud-native-open-liberty"]
+            "posts": ["full_java_ee_8_liberty_18002", "whats-next-microprofile-jakartaee", 
+                      "REST-Liberty-reactive-2018", "async-rest-jaxrs-microprofile", 
+                      "sharding-keys-jdbc43-19002", "integration-testing-with-testcontainers", 
+                      "microprofile22-liberty-19003", "jaxrs-reactive-extensions", 
+                      "jakarta-ee-naming", "java11-hotspot-19005", "production-experience-open-liberty", 
+                      "modernizing-javaee-cloud-native-open-liberty"]
         },
         {
             "name": "announcements",
-            "posts": ["open-sourcing-liberty", "javaone-sessions-open-liberty-team", "microprofile-12-open-liberty-17003", "jsf-implementation-open-liberty-17004", "full_java_ee_8_liberty_18002", "meet-us-at-oc1-and-ece", "REST-Liberty-reactive-2018", "new-4-weekly-release-schedule", "open-liberty-19001", "java-11", "devnexus-microprofile-open-liberty", "java11-hotspot-19005", "microprofile-rest-client-19006", "microprofile-30-developer-experience", "microprofile-context-propagation-19008", "microprofile-reactive-messaging-19009","configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", "liberty-dev-mode-vscode", "openshift-oauth-server-social-login-liberty-20001", "preview-microprofile-3-3-20002", "access-specific-kafka-properties-samesite-20003", "microprofile-3-3-open-liberty-20004", "2020-05-07-EJB-persistent-timers-20005"],
+            "posts": ["open-sourcing-liberty", "javaone-sessions-open-liberty-team", 
+                      "microprofile-12-open-liberty-17003", "jsf-implementation-open-liberty-17004", 
+                      "full_java_ee_8_liberty_18002", "meet-us-at-oc1-and-ece", 
+                      "REST-Liberty-reactive-2018", "new-4-weekly-release-schedule", 
+                      "open-liberty-19001", "java-11", 
+                      "devnexus-microprofile-open-liberty", "java11-hotspot-19005", 
+                      "microprofile-rest-client-19006", "microprofile-30-developer-experience", 
+                      "microprofile-context-propagation-19008", "microprofile-reactive-messaging-19009", 
+                      "configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", 
+                      "liberty-dev-mode-vscode", "openshift-oauth-server-social-login-liberty-20001", 
+                      "preview-microprofile-3-3-20002", "access-specific-kafka-properties-samesite-20003", 
+                      "microprofile-3-3-open-liberty-20004", "2020-05-07-EJB-persistent-timers-20005"],
             "featured": "true"
         },
         {
             "name": "release",
-            "posts": ["jsf-implementation-open-liberty-17004", "distributed-tracing-microservices-18001", "full_java_ee_8_liberty_18002", "get-more-metrics-microprofile20", "microprofile21-18004", "new-4-weekly-release-schedule", "open-liberty-19001", "sharding-keys-jdbc43-19002", "microprofile22-liberty-19003", "reactive-microservices-microprofile-19004", "java11-hotspot-19005", "microprofile-rest-client-19006", "microprofile-30-developer-experience", "microprofile-context-propagation-19008", "microprofile-reactive-messaging-19009", "configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", "microprofile-32-health-metrics-190012", "openshift-oauth-server-social-login-liberty-20001", "preview-microprofile-3-3-20002", "access-specific-kafka-properties-samesite-20003", "microprofile-3-3-open-liberty-20004", "2020-05-07-EJB-persistent-timers-20005"]
+            "posts": ["jsf-implementation-open-liberty-17004", "distributed-tracing-microservices-18001", 
+                      "full_java_ee_8_liberty_18002", "get-more-metrics-microprofile20", 
+                      "microprofile21-18004", "new-4-weekly-release-schedule", 
+                      "open-liberty-19001", "sharding-keys-jdbc43-19002", 
+                      "microprofile22-liberty-19003", "reactive-microservices-microprofile-19004", 
+                      "java11-hotspot-19005", "microprofile-rest-client-19006", 
+                      "microprofile-30-developer-experience", "microprofile-context-propagation-19008", 
+                      "microprofile-reactive-messaging-19009", "configure-logs-JSON-format-190010", 
+                      "diagnose-slow-requests-easily-190011", "microprofile-32-health-metrics-190012", 
+                      "openshift-oauth-server-social-login-liberty-20001", "preview-microprofile-3-3-20002", 
+                      "access-specific-kafka-properties-samesite-20003", "microprofile-3-3-open-liberty-20004", 
+                      "2020-05-07-EJB-persistent-timers-20005"]
         },
         {
             "name": "Maven",
-            "posts": ["installing-features-from-maven-dependencies", "build-and-push-spring-boot-docker-images", "microprofile-30-developer-experience", "dev-mode-liberty-maven-plugin"]
+            "posts": ["installing-features-from-maven-dependencies", "build-and-push-spring-boot-docker-images", 
+                      "microprofile-30-developer-experience", "dev-mode-liberty-maven-plugin"]
         },
         {
             "name": "security",
-            "posts": ["sharding-keys-jdbc43-19002", "microprofile-rest-client-19006","testing-database-connections-REST-APIs", "microprofile-32-health-metrics-190012", "access-specific-kafka-properties-samesite-20003", "set-samesite-attribute-cookies-liberty", "2020-05-07-EJB-persistent-timers-20005"]
+            "posts": ["sharding-keys-jdbc43-19002", "microprofile-rest-client-19006", 
+                      "testing-database-connections-REST-APIs", "microprofile-32-health-metrics-190012", 
+                      "access-specific-kafka-properties-samesite-20003", "set-samesite-attribute-cookies-liberty", 
+                      "2020-05-07-EJB-persistent-timers-20005"]
         },
         {
             "name": "Spring",
-            "posts": ["liberty-spring-boot", "optimizing-spring-boot-apps-for-docker", "creating-dual-layer-docker-images-for-spring-boot-apps", "build-and-push-spring-boot-docker-images"]
+            "posts": ["liberty-spring-boot", "creating-dual-layer-docker-images-for-spring-boot-apps", 
+                      "optimizing-spring-boot-apps-for-docker", "build-and-push-spring-boot-docker-images"]
         },
         {
             "name": "Docker",
-            "posts": ["optimizing-spring-boot-apps-for-docker", "creating-dual-layer-docker-images-for-spring-boot-apps", "build-and-push-spring-boot-docker-images","reactive-microservices-microprofile-19004", "distributed-tracing-microservices", "integration-testing-with-testcontainers","microprofile-30-developer-experience", "scala-open-liberty-kubernetes", "docker-open-liberty-raspberry-pi"]
+            "posts": ["optimizing-spring-boot-apps-for-docker", "build-and-push-spring-boot-docker-images", 
+                      "creating-dual-layer-docker-images-for-spring-boot-apps", "distributed-tracing-microservices", 
+                      "reactive-microservices-microprofile-19004", "integration-testing-with-testcontainers", 
+                      "microprofile-30-developer-experience", "scala-open-liberty-kubernetes", 
+                      "docker-open-liberty-raspberry-pi"]
         },
         {
             "name": "Gradle",
-            "posts": ["microprofile-12-open-liberty-17003", "installing-features-from-maven-dependencies","microprofile-30-developer-experience","reactive-microservices-microprofile-19004", "gradle-dev-mode-open-liberty"]
+            "posts": ["microprofile-12-open-liberty-17003", "installing-features-from-maven-dependencies", 
+                      "microprofile-30-developer-experience", "reactive-microservices-microprofile-19004", 
+                      "gradle-dev-mode-open-liberty"]
         },
         {
             "name": "PostgreSQL",
-            "posts": ["microprofile-rest-client-19006","java11-hotspot-19005","microprofile-30-developer-experience"]
+            "posts": ["microprofile-rest-client-19006", "java11-hotspot-19005", 
+                      "microprofile-30-developer-experience"]
         },
         {
             "name": "metrics",
-            "posts": ["alerts-slack-prometheus-alertmanager-open-liberty","Kibana-dashboard-visualizations","microprofile-30-developer-experience","microprofile-metrics-migration","microprofile-faulttolerance-1.1-metrics","get-more-metrics-microprofile20","configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", "openshift-oauth-server-social-login-liberty-20001", "modernizing-javaee-cloud-native-open-liberty", "microprofile-32-health-metrics-190012", "prometheus-alertmanager-rhocp-open-liberty", "microprofile-3-3-open-liberty-20004"]
+            "posts": ["alerts-slack-prometheus-alertmanager-open-liberty", "Kibana-dashboard-visualizations", 
+                      "microprofile-30-developer-experience", "microprofile-metrics-migration", 
+                      "microprofile-faulttolerance-1.1-metrics", "get-more-metrics-microprofile20", 
+                      "configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", 
+                      "openshift-oauth-server-social-login-liberty-20001", "modernizing-javaee-cloud-native-open-liberty", 
+                      "microprofile-32-health-metrics-190012", "prometheus-alertmanager-rhocp-open-liberty", 
+                      "microprofile-3-3-open-liberty-20004"]
         },
         {
             "name": "Jakarta EE",
-            "posts": ["jakarta-ee-naming", "whats-next-microprofile-jakartaee", "open-liberty-jakarta-ee", "production-experience-open-liberty", "modernizing-javaee-cloud-native-open-liberty", "crud-api-using-java-11"],
+            "posts": ["jakarta-ee-naming", "whats-next-microprofile-jakartaee", 
+                      "open-liberty-jakarta-ee", "production-experience-open-liberty", 
+                      "modernizing-javaee-cloud-native-open-liberty", "crud-api-using-java-11"],
             "featured": "true"
         },
         {
@@ -57,7 +123,10 @@
         },
         {
             "name": "community",
-            "posts": ["open-liberty-dev-mode", "java-microprofile-jwt-okta", "scala-open-liberty-kubernetes", "production-experience-open-liberty", "modernizing-javaee-cloud-native-open-liberty", "crud-api-using-java-11", "fast-setup-java-microservice-microprofile-starter"]
+            "posts": ["open-liberty-dev-mode", "java-microprofile-jwt-okta", 
+                      "scala-open-liberty-kubernetes", "production-experience-open-liberty", 
+                      "modernizing-javaee-cloud-native-open-liberty", "crud-api-using-java-11", 
+                      "fast-setup-java-microservice-microprofile-starter"]
         },
         {
             "name": "test",
@@ -65,19 +134,30 @@
         },
         {
             "name": "developer experience",
-            "posts": ["microprofile-30-developer-experience", "dev-mode-liberty-maven-plugin", "liberty-dev-mode-vscode", "open-liberty-dev-mode", "dev-mode-developer-experience", "integration-testing-with-testcontainers", "testing-database-connections-REST-APIs", "liberty-dev-mode", "gradle-dev-mode-open-liberty", "generate-microprofile-rest-client-code", "microprofile-3-3-open-liberty-20004", "fast-setup-java-microservice-microprofile-starter"]
+            "posts": ["microprofile-30-developer-experience", "dev-mode-liberty-maven-plugin", 
+                      "liberty-dev-mode-vscode", "open-liberty-dev-mode", 
+                      "dev-mode-developer-experience", "integration-testing-with-testcontainers", 
+                      "testing-database-connections-REST-APIs", "liberty-dev-mode", 
+                      "gradle-dev-mode-open-liberty", "generate-microprofile-rest-client-code", 
+                      "microprofile-3-3-open-liberty-20004", "fast-setup-java-microservice-microprofile-starter"]
         },
         {
             "name": "OpenShift",
-            "posts": ["infinispan-open-liberty-openshift", "openshift-oauth-server-social-login-liberty-20001", "ibm-red-hat-support-open-liberty", "prometheus-alertmanager-rhocp-open-liberty", "microprofile-3-3-open-liberty-20004"]
+            "posts": ["infinispan-open-liberty-openshift", "openshift-oauth-server-social-login-liberty-20001", 
+                      "ibm-red-hat-support-open-liberty", "prometheus-alertmanager-rhocp-open-liberty", 
+                      "microprofile-3-3-open-liberty-20004"]
         },
         {
             "name": "monitoring",
-            "posts": ["alerts-slack-prometheus-alertmanager-open-liberty","Kibana-dashboard-visualizations","custom-fields-json-logs", "diagnose-slow-requests-easily-190011", "configure-logs-JSON-format-190010", "prometheus-alertmanager-rhocp-open-liberty", "microprofile-3-3-open-liberty-20004", "2020-05-07-EJB-persistent-timers-20005"]
+            "posts": ["alerts-slack-prometheus-alertmanager-open-liberty", "Kibana-dashboard-visualizations", 
+                      "custom-fields-json-logs", "diagnose-slow-requests-easily-190011", 
+                      "configure-logs-JSON-format-190010", "prometheus-alertmanager-rhocp-open-liberty", 
+                      "microprofile-3-3-open-liberty-20004", "2020-05-07-EJB-persistent-timers-20005"]
         },
         {
             "name": "performance enhancements",
-            "posts": ["faster-startup-open-liberty", "openshift-oauth-server-social-login-liberty-20001", "faster-startup-Java-applications-criu", "http-response-compression"]
+            "posts": ["faster-startup-open-liberty", "openshift-oauth-server-social-login-liberty-20001", 
+                      "faster-startup-Java-applications-criu", "http-response-compression"]
         }
         
     ]

--- a/blog_tags.json
+++ b/blog_tags.json
@@ -2,144 +2,144 @@
     "blog_tags": [
         {
             "name": "MicroProfile",
-            "posts": ["microprofile-12-open-liberty-17003", "mpRestClient", 
-                      "distributed-tracing-microservices-18001", "microprofile-openapi-intro", 
-                      "java-microservices-microprofile", "whats-next-microprofile-jakartaee", 
-                      "dynamic-update-microservice-config", "get-more-metrics-microprofile20", 
-                      "microprofile-faulttolerance-1.1-metrics", "distributed-tracing-microservices", 
-                       "MicroProfile-Natural-Evolution-for-Microservices-Development", "microprofile21-18004", 
-                      "async-rest-jaxrs-microprofile", "mongodb-with-open-liberty", 
-                      "microprofile-concurrency", "integration-testing-with-testcontainers", 
-                      "developer-experience-microprofile-rest-client", "microprofile22-liberty-19003", 
-                      "reactive-microservices-microprofile-19004", "java11-hotspot-19005", 
-                      "microprofile-rest-client-19006","microprofile-30-developer-experience", 
-                      "microprofile-metrics-migration", "microprofile-context-propagation-19008", 
-                      "microprofile-reactive-messaging-19009", "microprofile-context-propagation", 
-                      "configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", 
-                      "microprofile-reactive-messaging", "java-microprofile-jwt-okta", 
-                      "production-experience-open-liberty", "openshift-oauth-server-social-login-liberty-20001", 
-                      "modernizing-javaee-cloud-native-open-liberty", "microprofile-32-health-metrics-190012", 
-                      "preview-microprofile-3-3-20002", "introduction-to-open-liberty", 
-                      "generate-microprofile-rest-client-code", "microprofile-3-3-open-liberty-20004", 
-                      "fast-setup-java-microservice-microprofile-starter"],
+            "posts": ["fast-setup-java-microservice-microprofile-starter", "microprofile-3-3-open-liberty-20004", 
+                      "generate-microprofile-rest-client-code", "introduction-to-open-liberty", 
+                      "preview-microprofile-3-3-20002", "microprofile-32-health-metrics-190012", 
+                      "modernizing-javaee-cloud-native-open-liberty", "openshift-oauth-server-social-login-liberty-20001", 
+                      "production-experience-open-liberty", "java-microprofile-jwt-okta", 
+                      "microprofile-reactive-messaging", "diagnose-slow-requests-easily-190011", 
+                      "configure-logs-JSON-format-190010", "microprofile-context-propagation", 
+                      "microprofile-reactive-messaging-19009", "microprofile-context-propagation-19008", 
+                      "microprofile-metrics-migration", "microprofile-30-developer-experience", 
+                      "microprofile-rest-client-19006", "java11-hotspot-19005", 
+                      "reactive-microservices-microprofile-19004", "microprofile22-liberty-19003", 
+                      "developer-experience-microprofile-rest-client", "integration-testing-with-testcontainers", 
+                      "microprofile-concurrency", "mongodb-with-open-liberty", 
+                      "async-rest-jaxrs-microprofile", "microprofile21-18004", 
+                      "MicroProfile-Natural-Evolution-for-Microservices-Development", "distributed-tracing-microservices", 
+                      "microprofile-faulttolerance-1.1-metrics", "get-more-metrics-microprofile20", 
+                      "dynamic-update-microservice-config", "whats-next-microprofile-jakartaee", 
+                      "java-microservices-microprofile", "microprofile-openapi-intro", 
+                      "distributed-tracing-microservices-18001", "mpRestClient", 
+                      "microprofile-12-open-liberty-17003"],
             "featured": "true"
         },
         {
             "name": "Java EE",
-            "posts": ["full_java_ee_8_liberty_18002", "whats-next-microprofile-jakartaee", 
-                      "REST-Liberty-reactive-2018", "async-rest-jaxrs-microprofile", 
-                      "sharding-keys-jdbc43-19002", "integration-testing-with-testcontainers", 
-                      "microprofile22-liberty-19003", "jaxrs-reactive-extensions", 
-                      "jakarta-ee-naming", "java11-hotspot-19005", "production-experience-open-liberty", 
-                      "modernizing-javaee-cloud-native-open-liberty"]
+            "posts": ["modernizing-javaee-cloud-native-open-liberty", "production-experience-open-liberty", 
+                      "java11-hotspot-19005", "jakarta-ee-naming", 
+                      "jaxrs-reactive-extensions", "microprofile22-liberty-19003", 
+                      "integration-testing-with-testcontainers", "sharding-keys-jdbc43-19002", 
+                      "async-rest-jaxrs-microprofile", "REST-Liberty-reactive-2018", 
+                      "whats-next-microprofile-jakartaee", "full_java_ee_8_liberty_18002"]
         },
         {
             "name": "announcements",
-            "posts": ["open-sourcing-liberty", "javaone-sessions-open-liberty-team", 
-                      "microprofile-12-open-liberty-17003", "jsf-implementation-open-liberty-17004", 
-                      "full_java_ee_8_liberty_18002", "meet-us-at-oc1-and-ece", 
-                      "REST-Liberty-reactive-2018", "new-4-weekly-release-schedule", 
-                      "open-liberty-19001", "java-11", 
-                      "devnexus-microprofile-open-liberty", "java11-hotspot-19005", 
-                      "microprofile-rest-client-19006", "microprofile-30-developer-experience", 
-                      "microprofile-context-propagation-19008", "microprofile-reactive-messaging-19009", 
-                      "configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", 
-                      "liberty-dev-mode-vscode", "openshift-oauth-server-social-login-liberty-20001", 
-                      "preview-microprofile-3-3-20002", "access-specific-kafka-properties-samesite-20003", 
-                      "microprofile-3-3-open-liberty-20004", "2020-05-07-EJB-persistent-timers-20005"],
+            "posts": ["2020-05-07-EJB-persistent-timers-20005", "microprofile-3-3-open-liberty-20004", 
+                      "access-specific-kafka-properties-samesite-20003", "preview-microprofile-3-3-20002", 
+                      "openshift-oauth-server-social-login-liberty-20001", "liberty-dev-mode-vscode", 
+                      "diagnose-slow-requests-easily-190011", "configure-logs-JSON-format-190010", 
+                      "microprofile-reactive-messaging-19009", "microprofile-context-propagation-19008", 
+                      "microprofile-30-developer-experience", "microprofile-rest-client-19006", 
+                      "java11-hotspot-19005", "devnexus-microprofile-open-liberty", 
+                      "java-11", "open-liberty-19001", 
+                      "new-4-weekly-release-schedule", "REST-Liberty-reactive-2018", 
+                      "meet-us-at-oc1-and-ece", "full_java_ee_8_liberty_18002", 
+                      "jsf-implementation-open-liberty-17004", "microprofile-12-open-liberty-17003", 
+                      "javaone-sessions-open-liberty-team", "open-sourcing-liberty"],
             "featured": "true"
         },
         {
             "name": "release",
-            "posts": ["jsf-implementation-open-liberty-17004", "distributed-tracing-microservices-18001", 
-                      "full_java_ee_8_liberty_18002", "get-more-metrics-microprofile20", 
-                      "microprofile21-18004", "new-4-weekly-release-schedule", 
-                      "open-liberty-19001", "sharding-keys-jdbc43-19002", 
-                      "microprofile22-liberty-19003", "reactive-microservices-microprofile-19004", 
-                      "java11-hotspot-19005", "microprofile-rest-client-19006", 
-                      "microprofile-30-developer-experience", "microprofile-context-propagation-19008", 
-                      "microprofile-reactive-messaging-19009", "configure-logs-JSON-format-190010", 
-                      "diagnose-slow-requests-easily-190011", "microprofile-32-health-metrics-190012", 
-                      "openshift-oauth-server-social-login-liberty-20001", "preview-microprofile-3-3-20002", 
-                      "access-specific-kafka-properties-samesite-20003", "microprofile-3-3-open-liberty-20004", 
-                      "2020-05-07-EJB-persistent-timers-20005"]
+            "posts": ["2020-05-07-EJB-persistent-timers-20005", "microprofile-3-3-open-liberty-20004", 
+                      "access-specific-kafka-properties-samesite-20003", "preview-microprofile-3-3-20002", 
+                      "openshift-oauth-server-social-login-liberty-20001", "microprofile-32-health-metrics-190012", 
+                      "diagnose-slow-requests-easily-190011", "configure-logs-JSON-format-190010", 
+                      "microprofile-reactive-messaging-19009", "microprofile-context-propagation-19008", 
+                      "microprofile-30-developer-experience", "microprofile-rest-client-19006", 
+                      "java11-hotspot-19005", "reactive-microservices-microprofile-19004", 
+                      "microprofile22-liberty-19003", "sharding-keys-jdbc43-19002", 
+                      "open-liberty-19001", "new-4-weekly-release-schedule", 
+                      "microprofile21-18004", "get-more-metrics-microprofile20", 
+                      "full_java_ee_8_liberty_18002", "distributed-tracing-microservices-18001", 
+                      "jsf-implementation-open-liberty-17004"]
         },
         {
             "name": "Maven",
-            "posts": ["installing-features-from-maven-dependencies", "build-and-push-spring-boot-docker-images", 
-                      "microprofile-30-developer-experience", "dev-mode-liberty-maven-plugin"]
+            "posts": ["dev-mode-liberty-maven-plugin", "microprofile-30-developer-experience", 
+                      "build-and-push-spring-boot-docker-images", "installing-features-from-maven-dependencies"]
         },
         {
             "name": "security",
-            "posts": ["sharding-keys-jdbc43-19002", "microprofile-rest-client-19006", 
-                      "testing-database-connections-REST-APIs", "microprofile-32-health-metrics-190012", 
-                      "access-specific-kafka-properties-samesite-20003", "set-samesite-attribute-cookies-liberty", 
-                      "2020-05-07-EJB-persistent-timers-20005"]
+            "posts": ["2020-05-07-EJB-persistent-timers-20005", "set-samesite-attribute-cookies-liberty", 
+                      "access-specific-kafka-properties-samesite-20003", "microprofile-32-health-metrics-190012", 
+                      "testing-database-connections-REST-APIs", "microprofile-rest-client-19006", 
+                      "sharding-keys-jdbc43-19002"]
         },
         {
             "name": "Spring",
-            "posts": ["liberty-spring-boot", "creating-dual-layer-docker-images-for-spring-boot-apps", 
-                      "optimizing-spring-boot-apps-for-docker", "build-and-push-spring-boot-docker-images"]
+            "posts": ["build-and-push-spring-boot-docker-images", "optimizing-spring-boot-apps-for-docker", 
+                      "creating-dual-layer-docker-images-for-spring-boot-apps", "liberty-spring-boot"]
         },
         {
             "name": "Docker",
-            "posts": ["optimizing-spring-boot-apps-for-docker", "build-and-push-spring-boot-docker-images", 
-                      "creating-dual-layer-docker-images-for-spring-boot-apps", "distributed-tracing-microservices", 
-                      "reactive-microservices-microprofile-19004", "integration-testing-with-testcontainers", 
-                      "microprofile-30-developer-experience", "scala-open-liberty-kubernetes", 
-                      "docker-open-liberty-raspberry-pi"]
+            "posts": ["docker-open-liberty-raspberry-pi", "scala-open-liberty-kubernetes", 
+                      "microprofile-30-developer-experience", "integration-testing-with-testcontainers", 
+                      "reactive-microservices-microprofile-19004", "distributed-tracing-microservices", 
+                      "creating-dual-layer-docker-images-for-spring-boot-apps", "build-and-push-spring-boot-docker-images", 
+                      "optimizing-spring-boot-apps-for-docker"]
         },
         {
             "name": "Gradle",
-            "posts": ["microprofile-12-open-liberty-17003", "installing-features-from-maven-dependencies", 
-                      "microprofile-30-developer-experience", "reactive-microservices-microprofile-19004", 
-                      "gradle-dev-mode-open-liberty"]
+            "posts": ["gradle-dev-mode-open-liberty", "reactive-microservices-microprofile-19004", 
+                      "microprofile-30-developer-experience", "installing-features-from-maven-dependencies", 
+                      "microprofile-12-open-liberty-17003"]
         },
         {
             "name": "PostgreSQL",
-            "posts": ["microprofile-rest-client-19006", "java11-hotspot-19005", 
-                      "microprofile-30-developer-experience"]
+            "posts": ["microprofile-30-developer-experience", "java11-hotspot-19005", 
+                      "microprofile-rest-client-19006"]
         },
         {
             "name": "metrics",
-            "posts": ["alerts-slack-prometheus-alertmanager-open-liberty", "Kibana-dashboard-visualizations", 
-                      "microprofile-30-developer-experience", "microprofile-metrics-migration", 
-                      "microprofile-faulttolerance-1.1-metrics", "get-more-metrics-microprofile20", 
-                      "configure-logs-JSON-format-190010", "diagnose-slow-requests-easily-190011", 
-                      "openshift-oauth-server-social-login-liberty-20001", "modernizing-javaee-cloud-native-open-liberty", 
-                      "microprofile-32-health-metrics-190012", "prometheus-alertmanager-rhocp-open-liberty", 
-                      "microprofile-3-3-open-liberty-20004"]
+            "posts": ["microprofile-3-3-open-liberty-20004", "prometheus-alertmanager-rhocp-open-liberty", 
+                      "microprofile-32-health-metrics-190012", "modernizing-javaee-cloud-native-open-liberty", 
+                      "openshift-oauth-server-social-login-liberty-20001", "diagnose-slow-requests-easily-190011", 
+                      "configure-logs-JSON-format-190010", "get-more-metrics-microprofile20", 
+                      "microprofile-faulttolerance-1.1-metrics", "microprofile-metrics-migration", 
+                      "microprofile-30-developer-experience", "Kibana-dashboard-visualizations", 
+                      "alerts-slack-prometheus-alertmanager-open-liberty"]
         },
         {
             "name": "Jakarta EE",
-            "posts": ["jakarta-ee-naming", "whats-next-microprofile-jakartaee", 
-                      "open-liberty-jakarta-ee", "production-experience-open-liberty", 
-                      "modernizing-javaee-cloud-native-open-liberty", "crud-api-using-java-11"],
+            "posts": ["crud-api-using-java-11", "modernizing-javaee-cloud-native-open-liberty", 
+                      "production-experience-open-liberty", "open-liberty-jakarta-ee", 
+                      "whats-next-microprofile-jakartaee", "jakarta-ee-naming"],
             "featured": "true"
         },
         {
             "name": "Kubernetes",
-            "posts": ["12-factor-microprofile-kubernetes", "scala-open-liberty-kubernetes"]
+            "posts": ["scala-open-liberty-kubernetes", "12-factor-microprofile-kubernetes"]
         },
         {
             "name": "community",
-            "posts": ["open-liberty-dev-mode", "java-microprofile-jwt-okta", 
-                      "scala-open-liberty-kubernetes", "production-experience-open-liberty", 
-                      "modernizing-javaee-cloud-native-open-liberty", "crud-api-using-java-11", 
-                      "fast-setup-java-microservice-microprofile-starter"]
+            "posts": ["fast-setup-java-microservice-microprofile-starter", "crud-api-using-java-11", 
+                      "modernizing-javaee-cloud-native-open-liberty", "production-experience-open-liberty", 
+                      "scala-open-liberty-kubernetes", "java-microprofile-jwt-okta", 
+                      "open-liberty-dev-mode"]
         },
         {
             "name": "test",
-            "posts": ["liberty-dev-mode-vscode", "testing-database-connections-REST-APIs"]
+            "posts": ["testing-database-connections-REST-APIs", "liberty-dev-mode-vscode"]
         },
         {
             "name": "developer experience",
-            "posts": ["microprofile-30-developer-experience", "dev-mode-liberty-maven-plugin", 
-                      "liberty-dev-mode-vscode", "open-liberty-dev-mode", 
-                      "dev-mode-developer-experience", "integration-testing-with-testcontainers", 
-                      "testing-database-connections-REST-APIs", "liberty-dev-mode", 
-                      "gradle-dev-mode-open-liberty", "generate-microprofile-rest-client-code", 
-                      "microprofile-3-3-open-liberty-20004", "fast-setup-java-microservice-microprofile-starter"]
+            "posts": ["fast-setup-java-microservice-microprofile-starter", "microprofile-3-3-open-liberty-20004", 
+                      "generate-microprofile-rest-client-code", "gradle-dev-mode-open-liberty", 
+                      "liberty-dev-mode", "testing-database-connections-REST-APIs", 
+                      "integration-testing-with-testcontainers", "dev-mode-developer-experience", 
+                      "open-liberty-dev-mode", "liberty-dev-mode-vscode", 
+                      "dev-mode-liberty-maven-plugin", "microprofile-30-developer-experience"]
         },
         {
             "name": "OpenShift",


### PR DESCRIPTION
To make the lists of posts for each tag easier to view, list 2 per line.  Also, the list has been reversed so that the latest post is first in the array, which should make it easier to associate with its tag.

Adding a bunch of people to the review to 'socialize' this intentional change.
In the future, we can consider having a common code style for editors/IDEs