### PR TITLE
Consistent use of servers vs members

### DIFF
--- a/publish/2020-05-07-EJB-persistent-timers-20005.adoc
+++ b/publish/2020-05-07-EJB-persistent-timers-20005.adoc
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Updates to EJB persistent timers coordination and failover across members is now available on Open Liberty 20.0.0.5"
+title: "Updates to EJB persistent timers coordination and failover across servers is now available on Open Liberty 20.0.0.5"
 categories: blog
 author_picture: https://avatars3.githubusercontent.com/tomjenningss
 author_github: https://github.com/tomjenningss
@@ -8,7 +8,7 @@ seo-title: Open Liberty 20.0.0.5 allows developers to add a configurable attribu
 seo-description: Open Liberty 20.0.0.5 allows developers to add a configurable attribute to an EJB Persistent Timer feature.
 blog_description: Open Liberty 20.0.0.5 allows developers to add a configurable attribute to an EJB Persistent Timer feature.
 ---
-= Updates to EJB persistent timers coordination and failover across members is now available on Open Liberty 20.0.0.5
+= Updates to EJB persistent timers coordination and failover across servers is now available on Open Liberty 20.0.0.5
 Tom Jennings <https://github.com/tomjenningss>
 :imagesdir: /
 :url-prefix:
@@ -71,7 +71,7 @@ image::img/blog/blog_btn_stack.svg[Ask a question on Stack Overflow, align="cent
 //tag::features[]
 
 [#EPT]
-=== EJB persistent timers coordination and failover across members
+=== EJB persistent timers coordination and failover across servers
 
 Prior to this feature, coordination of automatic EJB persistent timers across multiple Open Liberty servers was limited to ensuring that only a single instance of a timer is created across all servers by configuring the EJB timer service on each to persist timers to the same database. This caused a single timer instance to be created on one of the servers but without the ability to go to another server if the original server stops or crashes. To enable failover, this feature adds a new configurable attribute, `missedTaskThreshold`, which specifies the maximum amount of time that you want to allow for an execution of a persistent timer to complete before allowing another server to take over and run it instead.
 


### PR DESCRIPTION
"Members" brings thoughts of collectives and clusters which aren't relevant to OL too. The body of the text has changed to "servers" but the headings/title still say "members".

Don't mind who reviews but tagging both in case there was a reason for it saying members.