### PR TITLE
Update refresh_docker_image.sh

### DIFF
--- a/scripts/refresh_docker_image.sh
+++ b/scripts/refresh_docker_image.sh
@@ -1,5 +1,4 @@
-docker exec -it website rm -rf /home/jekyll/src/main/content/_drafts /home/jekyll/src/main/content/_posts /home/jekyll/src/main/content/img/blog
-docker cp blogs/drafts website:/home/jekyll/src/main/content/_drafts
+docker exec -it website rm -rf /home/jekyll/src/main/content/_posts /home/jekyll/src/main/content/img/blog
 docker cp blogs/publish website:/home/jekyll/src/main/content/_posts
 docker cp blogs/img/blog website:/home/jekyll/src/main/content/img
 docker cp blogs/blog_tags.json website:/home/jekyll/src/main/content

--- a/scripts/refresh_docker_image.sh
+++ b/scripts/refresh_docker_image.sh
@@ -1,4 +1,4 @@
 docker exec -it website rm -rf /home/jekyll/src/main/content/_posts /home/jekyll/src/main/content/img/blog
-docker cp blogs/publish website:/home/jekyll/src/main/content/_posts
+docker cp blogs/posts website:/home/jekyll/src/main/content/_posts
 docker cp blogs/img/blog website:/home/jekyll/src/main/content/img
 docker cp blogs/blog_tags.json website:/home/jekyll/src/main/content


### PR DESCRIPTION
We no longer use the draft directory once we switch to the branches pipeline instead of `publish` and `drafts` directories so remove the calls to handle draft blogs.