### PR TITLE
[#418] MP GraphQL 1.0 Blog

### DIFF
--- a/posts/2020-05-19-log4j-openshift-container-platform.adoc
+++ b/posts/2020-05-19-log4j-openshift-container-platform.adoc
@@ -1,0 +1,242 @@
+---
+layout: post
+title: "Send Log4j 2 logs to Red Hat OpenShift Container Platform EFK stack"
+categories: blog
+author_picture: https://avatars0.githubusercontent.com/u/31770221
+author_github: https://github.com/Yushan-Lin
+seo-title: Send Log4j 2 logs to Red Hat OpenShift Container Platform EFK stack - OpenLiberty.io
+seo-description: Send your Log4j 2 logs to the EFK stack in RHOCP so you can analyze all your Open Liberty server and application logs together on Kibana. This post describes three different ways to forward Log4j 2 logs to RHOCP's EFK stack using sidecar containers or the Log4j 2 to SLF4J Adapter.
+blog_description: "Send your Log4j 2 logs to the EFK stack in RHOCP so you can analyze all your Open Liberty server and application logs together on Kibana."
+---
+= Send Log4j 2 logs to Red Hat OpenShift Container Platform EFK stack
+Yushan Lin <https://github.com/Yushan-Lin>
+
+When developing applications, you can choose from many logging utility options based on your needs.
+One of these logging utilities, Log4j 2, is commonly used for logging in applications.
+Log4j 2 has an API that you can use to output log statements to various output targets.
+In this blog, we'll show you how to forward your Log4j 2 logs into Red Hat OpenShift Container Platform's (RHOCP) EFK (ElasticSearch, Fluentd, Kibana) stack so you can view and analyze them.
+We'll present two approaches to forward Log4j 2 logs using a sidecar container and a third approach to forward Log4j 2 logs to JUL (`java.util.logging`).
+
+You might want to visualize both your Log4j 2 application logs and Liberty logs on the same Kibana dashboard to better monitor your applications and servers.
+In Open Liberty logging, JUL logs are merged with Liberty logs and sent to `messages.log/console`, but Log4j 2 logs aren't merged with Liberty logs.
+Log4j 2 logs that are written to the file system aren't automatically picked up when you run your application in a Docker container in OpenShift.
+When you deploy your application on Open Liberty, you must specify where you want to send your Log4j 2 logs.
+
+image::/img/blog/log4j-rhocp-diagrams/current-problem.png[Logging problem diagram,width=70%,align="center"]
+
+== Sending Log4j 2 logs to RHOCP's EFK stack using sidecar containers
+
+In Kubernetes environments, the best practice is to send your logs to stdout. The platform will be set up to consume content from the pod's stdout and direct it to the logging facilities of the cluster.
+One of the ways to send your Log4j 2 logs to RHOCP's EFK stack is by using sidecar containers. Pods can have multiple containers that work together. While one container creates and writes to a log file, another link:https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/[sidecar container], in the same pod, can be configured to read those files from the first container. In this case, the sidecar container can:
+
+* Stream application logs to the application's own stdout.
+
+* Run a logging agent, which is configured to pick up logs from an application container.
+
+For either option, set up a shared volume for the directory of your application logs:
+
+. For your deployed application, modify the deployment to define the shared volume:
++
+```
+volumes:
+  - name: outputlog
+    emptyDir: {}
+```
+
+. Mount the volume to your main application container:
++
+```
+volumeMounts:
+  - name: outputlog
+    mountPath: /output/logs
+```
+
+=== Forward Log4j 2 logs to the application's stdout
+
+image::/img/blog/log4j-rhocp-diagrams/solution-1.png[Application stdout diagram,width=70%,align="center"]
+
+By streaming application logs to its own stdout, the Liberty server logs are separated from the application logs. In Kibana, the logs appear as if they came from the sidecar container of the same pod.
+
+. Configure a Log4j 2 Appender to send your logs to a File or RollingFile:
++
+```
+<Appenders>
+    <File name="File" fileName="${log-path}/app.log" append="true">
+      <JsonLayout compact="true" eventEol="true"/>
+    </File>
+    <RollingFile name="DailyRolling" fileName="${log-path}/myexample.log" append="true"
+    filePattern="${log-path}/myexample-%d{yyyy-MM-dd}-%i.log">
+        <JsonLayout compact="true" eventEol="true"/>
+      <Policies>
+           <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+      </Policies>
+    </RollingFile>
+</Appenders>
+```
+
+. Add the Appender as a reference to your Logger:
++
+```
+<Loggers>
+     ...
+     <Logger....>
+     <AppenderRef ref="File"/>
+     <AppenderRef ref="RollingFile"/>
+     </Logger>
+      ....
+</Loggers>
+```
++
+For more information about Log4j 2 Appenders, see the link:https://logging.apache.org/log4j/2.x/manual/appenders.html[Apache Appender documentation].
+
+. Modify your application deployment by adding a sidecar container that tails your application logs. Write the log to a persistent volume for storage.
++
+Create another container and mount the volume of the directory where the log is located. This example tails the logs to send them to stdout:
++
+```
+  - name: app-sidecar
+          image: 'linyusha/java-microprofile:latest'
+          args:
+            - /bin/sh
+            - '-c'
+            - tail -n+1 --retry -f /output/logs/app.log
+          resources: {}
+          volumeMounts:
+            - name: outputlog
+              mountPath: /output/logs
+```
+
+. On your Kibana dashboard, you should see the application logs under the project.* index along with your other Liberty server logs:
++
+[.img_border_light]
+image::/img/blog/log4j-rhocp-diagrams/log4j-rhocp-output.png[Kibana dashboard,width=70%,align="center"]
+
+=== Forward Log4j 2 logs using a logging agent
+
+You can create a sidecar container with a separate logging agent that's configured specifically to forward your application's logs. This gives you the flexibility to use Fluentd to specify where you want to send your Log4j 2 logs. In this case, we are directing our logs to stdout to send them to RHOCP EFK stack.
+
+. Create a Fluentd config map that specifies the `source` (where you want Fluentd to scrape your logs) and `match` (where you want to send the logs):
++
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+data:
+  fluentd.conf: |
+    <source>
+      @type tail
+      <parse>
+        @type json
+      </parse>
+      path /output/logs/app.log
+      pos_file /path/to/position/file/app.log.pos
+      tag project.*
+    </source>
+
+    <match **>
+      @type stdout
+    </match>
+```
+
+. Create a sidecar container running Fluentd. The pod mounts a volume where Fluentd can pick up its configuration data. To modify your deployment:
+
+.. Add the `configMap` as a volume to your deployment:
++
+```
+ volumes:
+  - name: outputlog
+    emptyDir: {}
+  - name: config-volume
+    configMap:
+      name: fluentd-config
+```
+
+.. Create the sidecar container with Fluentd as the logging agent:
++
+```
+  - name: count-agent
+    image: k8s.gcr.io/fluentd-gcp:1.30
+    env:
+    - name: FLUENTD_ARGS
+      value: -c /etc/fluentd-config/fluentd.conf
+    volumeMounts:
+    - name: outputlog
+      mountPath: /output/log
+    - name: config-volume
+      mountPath: /etc/fluentd-config
+```
+
+The following code snippet and sample output apply to both sidecar container scenarios: 
+
+* This code snippet is example log code in an application:
++
+```
+        LOGGER.info("hello liberty servlet info message!");
+        LOGGER.debug("hello liberty servlet debug message!");
+        LOGGER.log(Level.WARN, "hello liberty servlet warning message!");
+```
+
+* If you add the preceding code snippet to your application, the following example is a sample output to stdout:
++
+```
+{"timeMillis":1581629336498,"thread":"Default Executor-thread-20","level":"INFO","loggerName":"application.servlet.LibertyServlet","message":"hello liberty servlet info message!","endOfBatch":false,"loggerFqcn":"org.apache.logging.log4j.spi.AbstractLogger","threadId":65,"threadPriority":5}
+{"timeMillis":1581629336646,"thread":"Default Executor-thread-20","level":"DEBUG","loggerName":"application.servlet.LibertyServlet","message":"hello liberty servlet debug message!","endOfBatch":false,"loggerFqcn":"org.apache.logging.log4j.spi.AbstractLogger","threadId":65,"threadPriority":5}
+{"timeMillis":1581629336646,"thread":"Default Executor-thread-20","level":"WARN","loggerName":"application.servlet.LibertyServlet","message":"hello liberty servlet warning message!","endOfBatch":false,"loggerFqcn":"org.apache.logging.log4j.spi.AbstractLogger","threadId":65,"threadPriority":5}
+```
+
+== Sending Log4j 2 logs to JUL
+
+In the examples that use sidecar containers, Log4j 2 logs are forwarded to RHOCP, but they aren't merged with Liberty logs.
+An alternative way to forward your Log4j 2 logs to RHOCP is by merging your Log4j 2 logs with Liberty logs.
+To merge these logs, you can use the Log4j 2 to SLF4J Adapter to send Log4j 2 logs to JUL.
+
+=== Forward Log4j 2 logs using the Log4j 2 to SLF4J Adapter
+
+image::/img/blog/log4j-rhocp-diagrams/solution-2.png[Log4j 2 to SLF4J Adapter diagram,width=70%,align="center"]
+
+Another way to direct your Log4j 2 logs to RHOCP's EFK stack is using the link:https://logging.apache.org/log4j/2.x/log4j-to-slf4j/index.html[Log4j 2 to SLF4J Adapter]. SLF4J can be configured to use JUL as the underlying implementation. The Log4j 2 to SLF4J Adapter allows applications coded to the Log4j 2 API to be routed to SLF4J.
+
+You can use this technique to merge your Log4j 2 logs with Liberty logs. Using this adapter may cause some link:https://logging.apache.org/log4j/2.x/log4j-to-slf4j/index.html[loss of performance], as the Log4j 2 messages are formatted before they can be passed to SLF4J. After logs are passed to SLF4J, they're formatted and merged with Liberty logs before being passed to `console.log/stdout`.
+
+. To use this adapter, add the dependency to your `pom.xml` file:
++
+```
+		<dependency>
+		  <groupId>org.apache.logging.log4j</groupId>
+		  <artifactId>log4j-to-slf4j</artifactId>
+		  <version>2.13.0</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-jdk14</artifactId>
+		    <version>1.7.7</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-api</artifactId>
+		    <version>1.7.25</version>
+		</dependency>
+```
+
+. Enable JSON logging in Open Liberty by adding the appropriate environment variables in the `bootstrap.properties` file under your server directory:
++
+```
+# generate console log in json and route the following sources
+com.ibm.ws.logging.console.source=message, trace, ffdc, audit, accessLog
+com.ibm.ws.logging.console.format=json
+com.ibm.ws.logging.console.log.level=INFO
+```
+
+The following log is an example output:
+```
+{"type":"liberty_message","host":"192.168.0.104","ibm_userDir":"\/Users\/yushan.lin@ibm.com\/Documents\/archived-guide-log4j\/finish\/target\/liberty\/wlp\/usr\/","ibm_serverName":"log4j.sampleServer","message":"hello liberty servlet info message!","ibm_threadId":"00000035","ibm_datetime":"2020-02-13T11:27:07.789-0500","module":"application.servlet.LibertyServlet","loglevel":"INFO","ibm_methodName":"doGet","ibm_className":"application.servlet.LibertyServlet","ibm_sequence":"1581611227789_0000000000016","ext_thread":"Default Executor-thread-8"}
+{"type":"liberty_trace","host":"192.168.0.104","ibm_userDir":"\/Users\/yushan.lin@ibm.com\/Documents\/archived-guide-log4j\/finish\/target\/liberty\/wlp\/usr\/","ibm_serverName":"log4j.sampleServer","message":"hello liberty servlet debug message!","ibm_threadId":"00000035","ibm_datetime":"2020-02-13T11:27:07.791-0500","module":"application.servlet.LibertyServlet","loglevel":"FINE","ibm_methodName":"doGet","ibm_className":"application.servlet.LibertyServlet","ibm_sequence":"1581611227791_0000000000001","ext_thread":"Default Executor-thread-8"}
+{"type":"liberty_message","host":"192.168.0.104","ibm_userDir":"\/Users\/yushan.lin@ibm.com\/Documents\/archived-guide-log4j\/finish\/target\/liberty\/wlp\/usr\/","ibm_serverName":"log4j.sampleServer","message":"hello liberty servlet warning message!","ibm_threadId":"00000035","ibm_datetime":"2020-02-13T11:27:07.792-0500","module":"application.servlet.LibertyServlet","loglevel":"WARNING","ibm_methodName":"doGet","ibm_className":"application.servlet.LibertyServlet","ibm_sequence":"1581611227792_0000000000017","ext_thread":"Default Executor-thread-8"}
+```
+
+If you want to learn more about JSON logging with Open Liberty, check out this link:https://developer.ibm.com/videos/use-json-logging-in-open-liberty[short YouTube video] or this blog post about link:https://openliberty.io/blog/2019/12/03/custom-fields-json-logs.html[Adding custom fields to JSON logs in Open Liberty].
+
+== Summary
+
+As you've learned in this post, there are different ways to forward your Log4j 2 and other non-JUL logs to RHOCP's EFK stack. You can use a sidecar container to forward logs directly to stdout, or you can run the sidecar container as your logging agent. You can also implement the Log4j 2 to SLF4J Adapter to merge Log4j 2 logs with your Liberty logs and output them in JSON format. For more information about logging in Open Liberty, see the link:https://openliberty.io/docs/ref/general/#logging.html[Open Liberty logging documentation]. If you want to try out another step-by-step tutorial on logging in EFK, check out this link:https://kabanero.io/guides/app-logging-ocp-4-2/[Kabanero guide on Application Logging on RHOCP]. Or, if you want to learn about Open Liberty and the ELK (Elasticsearch, Logstash, Kibana) stack, check out link:https://developer.ibm.com/videos/send-open-liberty-logs-to-elastic-stack/[this video on Using Liberty with Elastic Stack (aka ELK)].

--- a/posts/2020-05-27-MPGraphQL-1.0.adoc
+++ b/posts/2020-05-27-MPGraphQL-1.0.adoc
@@ -1,0 +1,341 @@
+---
+layout: post
+title: "Have it your way with MicroProfile GraphQL!"
+categories: blog
+author_picture: https://avatars.githubusercontent.com/andymc12
+author_github: https://github.com/andymc12
+seo-title: Have it your way with MicroProfile GraphQL!
+seo-description: Open Liberty 20.0.0.6 allows developers to quickly and easily write GraphQL applications with MicroProfile.
+blog_description: Open Liberty 20.0.0.6 allows developers to quickly and easily write GraphQL applications with MicroProfile.
+---
+= Have it your way with MicroProfile GraphQL!
+Andy McCright <https://github.com/andymc12>
+:imagesdir: /
+:url-prefix:
+:url-about: /about/
+
+// tag::intro[]
+Open Liberty 20.0.0.6 introduces a new feature called `mpGraphQL-1.0` that implements the 
+link:https://github.com/eclipse/microprofile-graphql/releases/tag/1.0.2[MicroProfile GraphQL 1.0] specification. 
+
+If you're here reading about GraphQL in Open Liberty, then chances are that you already know a bit about GraphQL. If
+you would like to learn more about it, I recommend checking out the 
+link:https://graphql.org/learn/[tutorial at GraphQL.org]. In short, GraphQL is a remote data access API that addresses
+issues like under-fetching and over-fetching that are inherent in most RESTful applications. It allows clients to
+specify the exact data they want - to "have it their way".
+
+GraphQL applications use a schema that acts as a description of the data provided by the server and as a contract
+between the client and server. Most GraphQL programming models require developers to dual-maintain their schema and the
+application code that supports it. MicroProfile GraphQL takes a "code first" approach that allows developers to write
+Java code using annotations to mark GraphQL schema elements, and then the MP GraphQL implementation generates the schema
+at runtime. 
+
+In this blog post, we'll explore how easy it is to create GraphQL applications using this 
+link:https://github.com/OpenLiberty/sample-mp-graphql[sample].
+// end::intro[]
+
+// tag::setup[]
+== Setup
+
+To set up your Maven environment for developing a MP GraphQL application, you'll need a dependency like:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.eclipse.microprofile.graphql</groupId>
+    <artifactId>microprofile-graphql-api</artifactId>
+    <version>1.0.2</version>
+    <scope>provided</scope>
+</dependency>
+----
+
+I recommend using the link:https://openliberty.io/guides/maven-intro.html[Liberty Maven plugin], but it's not strictly
+necessary so long as you generate a WAR file for deployment.
+
+When configuring the Liberty server for deployment, make sure that the `featureManager` element in the server.xml file
+contains the `mpGraphQL-1.0` feature. For example:
+
+[source,xml]
+----
+<server>
+  <featureManager>
+    <feature>mpGraphQL-1.0</feature>
+    <feature>mpMetrics-2.3</feature>
+  </featureManager>
+  <!-- ... -->
+</server>
+----
+
+The `mpMetrics-2.3` feature is not required, but will track the number of GraphQL query/mutation invocations and
+cumulative time when enabled.
+
+Now that we've got things set up, let's look at the code:
+// end::setup[]
+
+// tag::coding[]
+== Coding
+
+A MicroProfile GraphQL application should have at least one root-level query and/or mutation. To create a query or
+mutation, you start with a public Java class annotated with `@GraphQLApi`. Then you add public methods that are
+annotated with `@Query` or `@Mutation` for query or mutation, respectively. The query/mutation methods must always
+return a non-void type. These method can return simple types like `String`, `int`, `double`, `boolean`, etc. which will
+be mapped to GraphQL scalars such as `String`, `Int`, `Float`, `Boolean`, etc. Alternatively, these methods could return
+custom Java types - the types would be mapped to GraphQL types and defined in the generated schema. For example, in the
+sample application, the `currentConditions` query method returns a type called `Conditions` - that type has properties
+such as `temperatureF`, `temperatureC`, `precipitationType`, `weatherText`, etc. The following schema is generated
+from the query and it's return value:
+
+[source]
+----
+type Conditions {
+  dayTime: Boolean!
+  epochTime: BigInteger!
+  hasPrecipitation: Boolean!
+  "ISO-8601"
+  localObservationDateTime: DateTime
+  location: String
+  precipitationType: PrecipType
+  temperatureC: Float!
+  temperatureF: Float!
+  weatherText: String
+  wetBulbTempF: Float!
+}
+
+"Query root"
+type Query {
+  currentConditions(location: String): Conditions
+  currentConditionsList(locations: [String]): [Conditions]
+}
+...
+----
+
+The `currentConditions` query has an argument, called `location`. In the Java code, the argument is represented by a
+method parameter. Like output types, arguments/parameters can be simple Java types (mapping to GraphQL scalars) or
+custom types, which would be mapped to input types in the generated schema.
+
+When mapping custom types, it is possible to change the name used in the schema - this is possible using the `@Name`
+annotation. For example, if we wanted to change the schema to display `tempInFahrenheit` instead of `temperatureF`, we
+could just add `@Name("tempInFahrenheit")` to the `temperatureF` field in the `Conditions` class.
+
+If your application uses JSON-B, then `@JsonbProperty`, `@JsonbDateFormat`, and `@JsonbNumberFormat` annotations can be
+used instead of `@Name`, `@DateFormat` or `@NumberFormat` - when both sets of annotations are used, the annotations from
+the MP GraphQL APIs take precedence over the JSON-B APIs when used for schema generation or query/mutation execution.
+
+Another useful annotation is `@Source`. This annotation can be used to add a field to an entity object that might be
+expensive to lookup or calculate, and so you might not want to spend the resources on the server side to compute that
+field when the client doesn't want it anyway.  Here's an example from the sample:
+
+[source,java]
+----
+    public double wetBulbTempF(@Source @Name("conditions") Conditions conditions) {
+        // TODO: pretend like this is a really expensive operation
+        // ...
+        return conditions.getTemperatureF() - 3.0;
+    }
+----
+
+This example is a little contrived, but it shows us that the `wetBulbTempF` field will only be computed if the client
+requests that field. This method is in a class annotated with `@GraphQLApi` (in this example, `WeatherService`) and it
+contains a parameter annotated with `@Source` that takes the entity object, `Conditions`. When a client issues a query
+or mutation which would return the `Conditions` entity, and that query/mutation specifies the `wetBulbTempF` field, then
+the `wetBulbTempF(Conditions conditions)` method will be invoked by the GraphQL implementation, passing in the
+`Conditions` object that was returned from the query/mutation method.
+// end::coding[]
+
+// tag::running[]
+== Running the app
+
+To run and test the GraphQL application, you simply need to deploy it as a Web Archive (WAR) file. The Liberty Maven
+Plugin makes it easy to build, deploy and test using Apache Maven. After you have cloned the sample from GitHub
+(`git clone git@github.com:OpenLiberty/sample-mp-graphql.git`) or downloaded the source ZIP file, just run:
+`mvn clean package liberty:run`
+
+This will build, package, and deploy the GraphQL application to the latest Open Liberty server runtime and start the 
+server and app. Then you can use the pre-packaged GraphiQL HTML interface to send queries or mutations at:
+`http://localhost:9080/mpGraphQLSample/graphiql.html`
+
+Here are a few sample queries and mutations that you could use to get started - you may see some interesting results:
+
+[source,graphql]
+----
+#Temperature (Fahrenheit) for Las Vegas
+query LasVegas {
+  currentConditions(location: "Las Vegas") {
+    temperatureF
+  }
+}
+----
+
+[source,graphql]
+----
+#Is it really always sunny in Philadelphia?
+query SunnyInPhilly {
+  currentConditions(location: "Philadelphia") {
+    weatherText
+  }
+}
+----
+
+[source,graphql]
+----
+# Weather conditions for three locations - one roundtrip
+query threeLocations {
+  atlanta: currentConditions(location: "Atlanta") {
+        hasPrecipitation
+        temperatureF
+        weatherText
+        precipitationType
+    }
+  newyork: currentConditions(location: "New York") {
+        hasPrecipitation
+        temperatureF
+        weatherText
+        precipitationType
+  }
+  chicago: currentConditions(location: "Chicago") {
+        hasPrecipitation
+        temperatureF
+        weatherText
+        precipitationType
+    }
+}
+----
+
+[source,graphql]
+----
+# See partial results when one portion of the query fails
+query fourLocations {
+  atlanta: currentConditions(location: "Atlanta") {
+        hasPrecipitation
+        temperatureF
+        weatherText
+        precipitationType
+        wetBulbTempF
+    }
+  nowhere: currentConditions(location: "Nowhere") {
+    hasPrecipitation
+        temperatureF
+        weatherText
+        precipitationType
+  }
+  newyork: currentConditions(location: "New York") {
+        hasPrecipitation
+        temperatureF
+        weatherText
+        precipitationType
+  }
+  chicago: currentConditions(location: "Chicago") {
+        hasPrecipitation
+        temperatureF
+        weatherText
+        precipitationType
+        wetBulbTempF
+    }
+}
+----
+
+[source,graphql]
+----
+# Reset the stored weather conditions
+mutation {
+  reset
+}
+----
+
+// end:: running[]
+
+// tag::authorization[]
+== Authorization
+
+It may be necessary to restrict access to certain queries/mutations to certain authenticated users. While it is not part
+of the MicroProfile GraphQL 1.0 specification (it is under consideration for a future version of the spec), Open Liberty
+makes authorization checks possible by using the `@DenyAll`, `@PermitAll`, and `@RolesAllowed` annotations. These
+annotations must be placed on the class or method of classes annotated with `@GraphQLApi`.
+
+When implementing authorization with MP GraphQL, you will need to enable the `appSecurity-3.0` (or 2.0) feature in the
+server configuration. You will also need to set up the user registry and web container metadata for authentication and
+authorization. In the sample, we use the basic user registry which defines two users, one for each of two roles:
+
+[source,xml]
+----
+  <basicRegistry id="basic" realm="sample-mp-graphql">
+     <user name="user1" password="user1pwd" />
+     <user name="user2" password="user2pwd" />
+     <group name="Role1">
+       <member name="user1"/>
+     </group>
+     <group name="Role2">
+       <member name="user2"/>
+     </group>
+   </basicRegistry>
+----
+
+This means that user1 is part of Role1 and user2 is part of Role2. The web.xml declares these roles, and also sets up
+form-based authentication so that when the appSecurity feature is enabled, clients will be prompted to log in using a
+web-based form before accessing the GraphiQL HTML page.  It also allows the application to prevent users other than
+those in Role2 to invoke the `reset` mutation method:
+
+[source,java]
+----
+    @RolesAllowed("Role2")
+    @Mutation
+    @Description("Reset the cached conditions so that new queries will return newly randomized weather data." +
+                 "Returns number of entries cleared.")
+    public int reset() {
+        int cleared = currentConditionsMap.size();
+        currentConditionsMap.clear();
+        return cleared;
+    }
+----
+
+
+// end::authorization[]
+
+// tag::metrics[]
+== Integration with MicroProfile Metrics
+
+If you enable the `mpMetrics-2.3` feature with `mpGraphQL-1.0`, Open Liberty will track the number of times a particular
+query or mutation method is invoked - and the cumulative time spent in that method. These metrics can be useful for
+determining what data is being accessed, how often, and where time is spent in execution.
+
+Metrics collection and reporting for GraphQL applications is not mentioned in either the MP GraphQL 1.0 spec or the
+MP Metrics 2.3 spec, so the actual stats are collected and reported under the "vendor" category. To see these stats,
+you can browse to:
+`http://localhost:9080/metrics/vendor`
+
+The stats will be prefixed with `vendor_mp_graphql_` and should look something like this:
+
+[source]
+----
+# TYPE vendor_mp_graphql_Query_currentConditions_total counter
+vendor_mp_graphql_Query_currentConditions_total 27
+# TYPE vendor_mp_graphql_Query_currentConditions_elapsedTime_seconds gauge
+vendor_mp_graphql_Query_currentConditions_elapsedTime_seconds 0.10273818800000001
+# TYPE vendor_mp_graphql_Conditions_wetBulbTempF_total counter
+vendor_mp_graphql_Conditions_wetBulbTempF_total 4
+# TYPE vendor_mp_graphql_Conditions_wetBulbTempF_elapsedTime_seconds gauge
+vendor_mp_graphql_Conditions_wetBulbTempF_elapsedTime_seconds 0.031866015000000004
+# TYPE vendor_mp_graphql_Mutation_reset_total counter
+vendor_mp_graphql_Mutation_reset_total 3
+# TYPE vendor_mp_graphql_Mutation_reset_elapsedTime_seconds gauge
+vendor_mp_graphql_Mutation_reset_elapsedTime_seconds 0.007540145000000001
+----
+// end::metrics[]
+
+// tag::summary[]
+== Summary
+
+GraphQL is a powerful and popular query language for remote data access. MicroProfile GraphQL makes it easy to develop
+GraphQL applications in Java. And now you use GraphQL in Open Liberty!
+// end::summary[]
+
+// tag::references[]
+== References
+
+- Learn GraphQL: https://graphql.org/learn/
+- MicroProfile GraphQL GitHub Project: https://github.com/eclipse/microprofile-graphql
+- MicroProfile GraphQL 1.0.2 Specification: https://download.eclipse.org/microprofile/microprofile-graphql-1.0.2/microprofile-graphql.html
+- MicroProfile GraphQL 1.0.2 API Docs: https://download.eclipse.org/microprofile/microprofile-graphql-1.0.2/apidocs/
+- Sample Application: https://github.com/OpenLiberty/sample-mp-graphql
+- Open Liberty: https://openliberty.io
+// end::references[]


### PR DESCRIPTION
This provides the blog post for MP GraphQL 1.0, shipping in Open Liberty 20.0.0.6.  It fixes #418. 

The instructions say to checkout based on the `prod` branch, but open the PR against the `draft` branch - that ended up pulling in some other commits that are presumably in prod, but not draft.  I'll plan to leave them in this PR for now - ideally these would get merged to draft too so that other users don't see extra, unrelated commits with their PRs.

@lauracowen please take a look at the changes in 2020-05-27-MPGraphQL-1.0.adoc and let me know if you have any suggestions/corrections/etc.  
Thanks!  Andy