### PR TITLE
Update the description of what the Asynchronous annotation does

### DIFF
--- a/posts/2020-06-03-asynchronous-programming-made-resilient-with-mpft.adoc
+++ b/posts/2020-06-03-asynchronous-programming-made-resilient-with-mpft.adoc
@@ -30,7 +30,7 @@ But there's one, in particular, that's going to help you make your asynchronous 
 Adding the `@Asynchronous` annotation to a method does two things:
 
 1. Runs the method asynchronously
-2. Allows Fault Tolerance strategies to be applied to asynchronous methods
+2. If the method returns a `CompletionStage`, applies other Fault Tolerance strategies to the result of the `CompletionStage`, rather than to the result of the method
 
 Adding the `@Asynchronous` annotation to a method makes the method run asynchronously, meaning that rather than the annotated method running straight away on the main thread when it's called, it will run sometime later, usually on another thread. To use it, you need to add the `@Asynchronous` annotation to a method, and it must return either a https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html[`CompletionStage`] or a https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Future.html[`Future`]. You cannot apply Fault Tolerance to a returned `Future` (see why <<CS-preference, here>>), so a `CompletionStage` is preferred.
 
@@ -53,7 +53,10 @@ Usually when a method is called, it returns a result. However, when the `@Asynch
 image::/img/blog/FT-basic-asynchronous-execution.png[Fault Tolerance asynchronous execution flow]
 
 Sometime later, the method runs and returns a `CompletionStage` or `Future`.
-Now, Fault Tolerance completes the `CompletionStage` or `Future` that was returned earlier, with the value that was returned from the method. You might be wondering, *_"What if the returned result is an exception? What can I do?"_*. Read along.
+
+If the method returns a `Future`, then the last step is for Fault Tolerance to update the `Future` it previously returned to the user so that it delegates to the `Future` returned from the method, allowing the user to see the result from the method.
+
+However, if the method returns a `CompletionStage`, Fault Tolerance waits for the `CompletionStage` to complete, before completing the `CompletionStage` it previously returned to the user. Additionally, if the `CompletionStage` from the method completes with an _exception_, then other Fault Tolerance policies are applied, just as if that exception was thrown from the method body itself. This last step is crucial for allowing Fault Tolerance to work with other APIs that return a `CompletionStage`, as we'll see in the next section.
 
 == `@Asynchronous` use cases
 So `@Asynchronous` sounds great, right? But how can you use it to make your asynchronous programs resilient? Let's go through two use cases:


### PR DESCRIPTION
The second point was describing something you could usefully do with
`@Asynchronous`, and it wasn't referenced at all in the following text.

Update the second point so that it describes what FT actually does when
`@Asynchronous` is present on a method and add detail later in the section
explaining this in more detail.

The following section entirely covers the use case which was described
by the old text for point 2.