### PR TITLE
Adding tags for GraphQL and Jakarta EE beta blog posts

### DIFF
--- a/blog_tags.json
+++ b/blog_tags.json
@@ -2,7 +2,8 @@
     "blog_tags": [
         {
             "name": "announcements",
-            "posts": ["graphql-open-liberty-20006","EJB-persistent-timers-20005", "microprofile-3-3-open-liberty-20004",
+            "posts": ["jakarta-ee-9-open-liberty-20007beta",
+                "graphql-open-liberty-20006","EJB-persistent-timers-20005", "microprofile-3-3-open-liberty-20004",
                       "access-specific-kafka-properties-samesite-20003", "preview-microprofile-3-3-20002",
                       "openshift-oauth-server-social-login-liberty-20001", "liberty-dev-mode-vscode",
                       "diagnose-slow-requests-easily-190011", "configure-logs-JSON-format-190010",
@@ -17,7 +18,8 @@
             "featured": "true"
         },{
             "name": "MicroProfile",
-            "posts": ["asynchronous-programming-microprofile-fault-tolerance-part-2", "asynchronous-programming-microprofile-fault-tolerance",
+            "posts": ["microprofile-graphql-open-liberty",
+                "asynchronous-programming-microprofile-fault-tolerance-part-2", "asynchronous-programming-microprofile-fault-tolerance",
                       "fast-setup-java-microservice-microprofile-starter", "microprofile-3-3-open-liberty-20004",
                       "generate-microprofile-rest-client-code", "introduction-to-open-liberty",
                       "preview-microprofile-3-3-20002", "microprofile-32-health-metrics-190012",
@@ -63,6 +65,10 @@
                       "microprofile21-18004", "get-more-metrics-microprofile20",
                       "full_java_ee_8_liberty_18002", "distributed-tracing-microservices-18001",
                       "jsf-implementation-open-liberty-17004"]
+        },
+        {
+            "name": "beta",
+            "posts": ["jakarta-ee-9-open-liberty-20007beta"]
         },
         {
             "name": "Maven",
@@ -114,7 +120,8 @@
         },
         {
             "name": "Jakarta EE",
-            "posts": ["crud-api-using-java-11", "modernizing-javaee-cloud-native-open-liberty",
+            "posts": ["jakarta-ee-9-open-liberty-20007beta",
+                "crud-api-using-java-11", "modernizing-javaee-cloud-native-open-liberty",
                       "production-experience-open-liberty", "open-liberty-jakarta-ee",
                       "whats-next-microprofile-jakartaee", "jakarta-ee-naming"],
             "featured": "true"


### PR DESCRIPTION
- Add missing tag for GraphQL blog post
- Add tags for upcoming Jakarta EE beta blog post
- Create new 'beta' tag to correspond with 'release' tag used for GA releases