### PR TITLE
remove extra end tag

### DIFF
--- a/posts/2020-07-02-disable-default-cookies-20007.adoc
+++ b/posts/2020-07-02-disable-default-cookies-20007.adoc
@@ -101,8 +101,6 @@ Disable LTPA cookies for SPNEGO in the `server.xml`:
 </server>
 ----
 
-//end::features[]
-
 [#JWT-cookie]
 === Choose to disable JWT SSO cookie 
 


### PR DESCRIPTION
remove superfluous `end::features` tag at line 103. Correct tag is already at line 123. Fix required to resolve build error with the Open Liberty in Red Hat 20.0.0.7 release notes, which includes this file remotely