### PR TITLE
Move intro end tag

### DIFF
--- a/posts/2020-07-02-disable-default-cookies-20007.adoc
+++ b/posts/2020-07-02-disable-default-cookies-20007.adoc
@@ -22,8 +22,9 @@ In link:{url-about}[Open Liberty] 20.0.0.7:
 
 * <<LTPA-cookie, Choose to disable LTPA cookies for TAI or SPNEGO>>
 * <<JWT-cookie, Choose to disable JWT cookies>>
-// end::intro[]
 * <<significant-bug-fixes, Significant bugs fixed in this release>>
+
+// end::intro[]
 
 If you're interested in what's coming soon in Open Liberty, take a look at our <<previews,current development builds>> which include gRPC with Open Liberty.
 
@@ -119,8 +120,6 @@ Disable JWT cookies for JWT SSO in the `server.xml`:
 </server>
 ----
 
-//end::features[]
-
 [#significant-bug-fixes]
 == Significant bugs fixed in this release
 
@@ -141,6 +140,8 @@ In some specific cases, Liberty does not update its HTTP/2 read window quickly e
 //=== Fault Tolerance 2.1 missing dependency
 
 //We've identified a bug in MicroProfile Fault Tolerance 2.1 API (no issues in any other versions) which caused the error message `The import org.eclipse.microprofile.faulttolerance cannot be resolved` to appear instead of the dependency getting properly resolved.  The bug has been fixed by adding the necessary dependency JAR and the feature now resolves correctly
+
+//end::features[]
 
 [#previews]
 == Previews of early implementations available in development builds

--- a/posts/2020-07-02-disable-default-cookies-20007.adoc
+++ b/posts/2020-07-02-disable-default-cookies-20007.adoc
@@ -22,10 +22,11 @@ In link:{url-about}[Open Liberty] 20.0.0.7:
 
 * <<LTPA-cookie, Choose to disable LTPA cookies for TAI or SPNEGO>>
 * <<JWT-cookie, Choose to disable JWT cookies>>
+// end::intro[]
 * <<significant-bug-fixes, Significant bugs fixed in this release>>
 
 If you're interested in what's coming soon in Open Liberty, take a look at our <<previews,current development builds>> which include gRPC with Open Liberty.
-// end::intro[]
+
 
 // tag::run[]
 [#run]


### PR DESCRIPTION
Move the `intro::end` tag to avoid pulling in anchor links to the Red Hat build for areas of the doc that aren't included there.