### PR TITLE
Update 2020-07-30-json-logging-open-liberty-20008.adoc

### DIFF
--- a/posts/2020-07-30-json-logging-open-liberty-20008.adoc
+++ b/posts/2020-07-30-json-logging-open-liberty-20008.adoc
@@ -1,14 +1,14 @@
 ---
 layout: post
-title: "Access HTTP log fields in JSON logs and write JSON directly to system.out without wrapping on Open Liberty 20.0.0.8"
+title: "Customize HTTP access log fields in JSON logs and write JSON directly to system.out without wrapping on Open Liberty 20.0.0.8"
 categories: blog
 author_picture: https://avatars3.githubusercontent.com/jakub-pomykala
 author_github: https://github.com/jakub-pomykala
-seo-title: Access HTTP log fields in JSON logs and write JSON directly to system.out without wrapping on Open Liberty 20.0.0.8 - OpenLiberty.io
-seo-description: With Open Liberty 20.0.0.8 you can now access HTTP log fields in JSON logs and also write JSON directly to system.out without wrapping in the liberty_message event.
-blog_description: With Open Liberty 20.0.0.8 you can now access HTTP log fields in JSON logs and also write JSON directly to system.out without wrapping in the liberty_message event.
+seo-title: Customize HTTP access log fields in JSON logs and write JSON directly to system.out without wrapping on Open Liberty 20.0.0.8 - OpenLiberty.io
+seo-description: With Open Liberty 20.0.0.8 you can now customize HTTP access log fields in JSON logs and also write JSON directly to system.out without wrapping in the liberty_message event.
+blog_description: With Open Liberty 20.0.0.8 you can now customize HTTP access log fields in JSON logs and also write JSON directly to system.out without wrapping in the liberty_message event.
 ---
-= Access HTTP log fields in JSON logs and write JSON directly to system.out without wrapping on Open Liberty 20.0.0.8
+= Customize HTTP access log fields in JSON logs and write JSON directly to system.out without wrapping on Open Liberty 20.0.0.8
 Jakub Pomykala <https://github.com/jakub-pomykala>
 :imagesdir: /
 :url-prefix:
@@ -18,7 +18,7 @@ Jakub Pomykala <https://github.com/jakub-pomykala>
 // tag::intro[]
 
 
-With Open Liberty 20.0.0.8 you can now access HTTP log fields in JSON logs which allows you to include fields from the `accessLogging logFormat` attribute in your JSON logs. The update also allows for JSON to be written directly to `system.out` without wrapping in the `liberty_message` event.
+With Open Liberty 20.0.0.8 you can now customize HTTP access log fields in JSON logs which allows you to include fields from the `accessLogging logFormat` attribute in your JSON logs. The update also allows for JSON to be written directly to `system.out` without wrapping in the `liberty_message` event.
 
 
 In link:{url-about}[Open Liberty] 20.0.0.8:


### PR DESCRIPTION
Changed the title from "Access HTTP logs" to "Customise HTTP access logs" 