### PR TITLE
Wrong link for bug fixes in 20.0.0.9

### DIFF
--- a/posts/2020-08-28-graphql-apis-open-liberty-20009.adoc
+++ b/posts/2020-08-28-graphql-apis-open-liberty-20009.adoc
@@ -107,7 +107,7 @@ image::img/blog/GraphiQL_UI.png[GraphiQL user interface,width=70%,align="center"
 [#bugs]
 == Significant bugs fixed in this release
 
-We’ve spent some time fixing bugs. The following sections describe just some of the issues we resolved in this release. If you’re interested, here's the full list of link:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A20007+label%3A%22release+bug%22+[fixed bugs in 20.0.0.9].
+We’ve spent some time fixing bugs. The following sections describe just some of the issues we resolved in this release. If you’re interested, here's the full list of link:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A20009+label%3A%22release+bug%22+[fixed bugs in 20.0.0.9].
 
 
 === Change your SSL config without restarting your server

--- a/posts/2020-08-28-graphql-apis-open-liberty-20009.adoc
+++ b/posts/2020-08-28-graphql-apis-open-liberty-20009.adoc
@@ -113,7 +113,7 @@ We’ve spent some time fixing bugs. The following sections describe just some o
 === Change your SSL config without restarting your server
 
 If you use the JAX-RS Client in your application to access SSL-secured RESTful services, then you will likely have a key store and/or trust store configured. These SSL settings enable you to ensure you are communicating with the endpoint you expect - and that nobody else is listening in! These settings also enable SSL-based client authentication.
-Whatever you use these SSL settings for, if you need to change them, then that meant that you would need to restart your server so that the clients could pick up the new settings. Well, that is a thing of the past! Starting in 20.0.0.9, JJAX-RS clients can now dynamically adjust to changes in the SSL configuration. This should rapidly improve app development and deployment! Resolved in issue link:https://github.com/OpenLiberty/open-liberty/issues/13027[#13027].
+Whatever you use these SSL settings for, if you need to change them, then that meant that you would need to restart your server so that the clients could pick up the new settings. Well, that is a thing of the past! Starting in 20.0.0.9, JAX-RS clients can now dynamically adjust to changes in the SSL configuration. This should rapidly improve app development and deployment! Resolved in issue link:https://github.com/OpenLiberty/open-liberty/issues/13027[#13027].
 
 
 === Occasional error during Arquillian testing


### PR DESCRIPTION
Current link is pointing to 20.0.0.7 instead of 20.0.0.9