### PR TITLE
changes in Try it now section for All-beta in beta-post template

### DIFF
--- a/templates/beta-post.adoc
+++ b/templates/beta-post.adoc
@@ -103,7 +103,7 @@ To enable the new beta features in your app, add them to your `server.xml`:
 
 === Try it now 
 
-To try out these Jakarta EE 9 features on Open Liberty in a lightweight package, just update your build tools to pull the Open Liberty Jakarta EE 9 Beta Features package instead of the main release. The beta works with Java SE 14, Java SE 11, or Java SE 8.
+To try out these features, just update your build tools to pull the Open Liberty All Beta Features package instead of the main release. The beta works with Java SE 14, Java SE 11, or Java SE 8.
 
 If you're using link:{url-prefix}/guides/maven-intro.html[Maven], here are the coordinates:
 


### PR DESCRIPTION
Seems like I have copied the description from the `try it now` section for Jakarta EE 9 over to the All Beta section instead of adding the right description