### PR TITLE
OCP Log Forwarding - update 3

### DIFF
--- a/posts/2020-10-20-ocp-log-forwarding.adoc
+++ b/posts/2020-10-20-ocp-log-forwarding.adoc
@@ -408,10 +408,10 @@ image::/img/blog/splunk-dashboard.png[Splunk-Dashboard,width=70%,align="center"]
 
 If you find that there are no logs present on Splunk when you are done configuring, there are a few approaches to diagnose the issue.
 
-*Connection between FluentD and Splunk*
+*Connection between Fluentd and Splunk*
 
-* Ensure that the Spunk HEC token is correct
-* View the container logs from the FluentD instance and Splunk instance for warnings or errors
+* Ensure that the Splunk HEC token is correct
+* View the container logs from the Fluentd instance and Splunk instance for warnings or errors
 
 *Connection between the OCP cluster and the Fluentd instance*
 


### PR DESCRIPTION
missed changing two FluentD to Fluentd and misspelt _Splunk_