### PR TITLE
Fix for discrepancy in 21.0.0.1-beta

### DIFF
--- a/posts/2020-11-24-microprofile-rest-client-kubernetes-secrets-21001beta.adoc
+++ b/posts/2020-11-24-microprofile-rest-client-kubernetes-secrets-21001beta.adoc
@@ -69,17 +69,17 @@ In a cloud environment, sensitive information such as passwords and OAuth tokens
 
 To make use of this function, the Kubernetes secrets need to be mapped to the file system, either by using the service binding operator or by mounting the secrets to a volume in the pod definition. Files will be read from the location defined in the `SERVICE_BINDING_ROOT` environment variable, which defaults to `WLP_CONFIG_DIR`/bindings. The variable name will be taken from the name of the file, and the value will be the contents of the file.
 
-For example, we may have a Kubernetes secret named 'account_database' that contains a username and password:
+For example, we may have a Kubernetes secret named 'account-database' that contains a username and password:
 
 [.img_border_dark]
-image::img/blog/blog_21001_beta_username_password.png[align="center",Image of Kubernetes secret named 'account_database']
+image::img/blog/blog_21001_beta_username_password.png[align="center",Image of Kubernetes secret named 'account-database']
 
 The service binding operator can automatically map that secret to the file system, or it could be done manually in a deployment definition:
 
 [.img_border_dark]
-image::img/blog/blog_21001_deployment_definition.png[align="center",Image of Kubernetes secret named 'account_database']
+image::img/blog/blog_21001_deployment_definition.png[align="center",Image of Kubernetes secret named 'account-database']
 
-The above definition will result in the files `/bindings/account_database/username` and `/bindings/account_database/password` being created when the pod is created. Liberty will create variables from both files, and users can access them using normal Liberty variable syntax, `${account_database/username}` and `${account_database/password}`.
+The above definition will result in the files `/bindings/account-database/username` and `/bindings/account-database/password` being created when the pod is created. Liberty will create variables from both files, and users can access them using normal Liberty variable syntax, `${account-database/username}` and `${account-database/password}`.
 
 For more information:
 


### PR DESCRIPTION
In section **Using Kubernetes secrets in Liberty variables** where `acount_database` did not match `acount-database` within in the screenshot.