### PR TITLE
Changing "messaging 3.0" to "Jakarta Messaging 3.0"

### DIFF
--- a/posts/2020-11-24-microprofile-rest-client-kubernetes-secrets-21001beta.adoc
+++ b/posts/2020-11-24-microprofile-rest-client-kubernetes-secrets-21001beta.adoc
@@ -178,7 +178,7 @@ The `enterpriseBeansPersistentTimer-4.0` feature enables the use of persistent t
 
 
 [#messaging]
-=== Messaging 3.0
+=== Jakarta Messaging 3.0
 
 Jakarta Messaging is an API and services that enable applications to create, send, and receive messages via loosely coupled, reliable asynchronous communications. Support for version 3.0 updates the API and services to the jakarta.* namespace and introduces four new features for Jakarta EE 9: `messaging-3.0`, `messagingClient-3.0`, `messagingServer-3.0`, `messagingSecurity-3.0`.
 


### PR DESCRIPTION
@dazavala has noticed that the heading is wrong. It is supposed to be "Jakarta Messaging 3.0"