### PR TITLE
Add blog redirects file, moved from the ui repo

### DIFF
--- a/blog-redirects.properties
+++ b/blog-redirects.properties
@@ -1,0 +1,11 @@
+# Blogs redirects
+/news/=/blog/
+/news=/blog/
+/news/*=/blog/
+/blogs=/blog/
+/blogs/=/blog/
+/blog/2017/11/29/liberty-spring-boot.html=/guides/spring-boot.html
+/blog/2019/03/01/microprofile-concurrency.html=/blog/2019/08/16/microprofile-context-propagation.html
+/blog/2019/05/24/testing-database-connections-REST-APIs.html=/blog/2019/09/13/testing-database-connections-REST-APIs.html
+/blog/2019/09/13/microprofile-reactive-messsaging-19009.html=/blog/2019/09/13/microprofile-reactive-messaging-19009.html
+/blog/2019/11/07/ibm-red-hat-support-open-liberty.html=/blog/?search=OpenShift


### PR DESCRIPTION
The build will now copy over and use this redirect file, so the blogs team can better control the old/new url mappings for blogs.