### PR TITLE
Add XML Web Services to 21.0.0.2-beta blog

### DIFF
--- a/posts/2021-01-26-ee9-messaging-security-21002-beta.adoc
+++ b/posts/2021-01-26-ee9-messaging-security-21002-beta.adoc
@@ -119,11 +119,9 @@ Additional information about the Jakarta Security 2.0 specification can be found
 [#xmlws]
 === Jakarta XML Web Services 3.0
 
-Jakarta XML Web Services 3.0 is an API that enables applications to create SOAP based Web Services. Support provides the following updated APIs: XML Web Services 3.0, Jakarta Web Services Metadata 3.0, Jakarta SOAP with Attachments 2.0. Support also introduces the `xmlWS-3.0` feature, as well as the Application Client Container support for XML Web Services 3.0 via the `jakartaeeClient-9.0` convenience feature.
+Jakarta XML Web Services 3.0 is an API that enables applications to create SOAP based Web Services. The `xmlWS-3.0` feature provides API updates to the Jakarta XML Web Services 3.0 API, Jakarta Web Services Metadata 3.0 API and Jakarta SOAP with Attachments 2.0 API. The `jakartaeeClient-9.0` feature has been also been updated to provide Application Client Container support for the Jakarta XML Web Services 3.0 API.
 
-The `xmlWS-3.0` feature provides the Jakarta EE 9 XML Web Services 3.0 tools for Top Down and Bottom Up Web Services Creation: `wsgen` and `wsimport`. These can be found in a new location in the Open Liberty image: wlp/bin/xmlWS/. Both commands preform nearly identical to the Jakarta EE 8 tooling, with the exception that the `-target` argument is no longer required.
-
-The implementation of Jakarta XML Web Services 3.0 in Open Liberty is based on Apache CXF 3.4.1. This provides numerous improvements and fixes over the forked version of CXF 2.6.2 in use by the Jakarta EE 8 `jaxws-2.3` feature (Note: Not all CXF 3.4.1 functionality is available in `xmlWS-3.0`, but watch this space for updates.)
+The `xmlWS-3.0` feature provides the Jakarta EE 9 XML Web Services 3.0 tools for Top Down and Bottom Up Web Services Creation: `wsgen` and `wsimport`. These can be found in a new location in the Open Liberty image: wlp/bin/xmlWS/. Both commands perform nearly identical to the Jakarta EE 8 tooling, with the exception that the `-target` argument is no longer required.
 
 To enable the new Jakarta EE 9 XML Web Services 3.0 feature, add the xmlWS-3.0 feature to your server.xml. Here's an example of what the feature configuration looks like:
 
@@ -143,7 +141,7 @@ To run Jakarta XML Web Services on the Application Client Container: Here's an e
  </featureManager>
 ----
 
-For more information see the link:https://jakarta.ee/specifications/xml-web-services/[Jakarta XML Web Services Specification], and the link:https://cxf.apache.org/docs/34-migration-guide.html[Apache CXF 3.4 Migration Guide].
+For more information see the link:https://jakarta.ee/specifications/xml-web-services/3.0/[Jakarta XML Web Services Specification], and the link:https://cxf.apache.org/docs/34-migration-guide.html[Apache CXF 3.4 Migration Guide].
 
 Enable the Jakarta EE 9 beta features in your app's `server.xml`. You can enable the individual features you want or you can just add the Jakarta EE 9 convenience feature to enable all of the Jakarta EE 9 beta features at once:
 

--- a/posts/2021-01-26-ee9-messaging-security-21002-beta.adoc
+++ b/posts/2021-01-26-ee9-messaging-security-21002-beta.adoc
@@ -35,8 +35,8 @@ This Open Liberty beta introduces the following Jakarta EE 9 features which now 
 
 * <<messaging, Jakarta Messaging 3.0 (`messaging-3.0, messagingClient-3.0, messagingServer-3.0, messagingSecurity-3.0`)>>
 * <<security, Jakarta Security 2.0 (`appSecurity-4.0, appSecurityClient-1.0`)>>
+* <<xmlws, Jakarta XML Web Services 3.0 (`xmlWS-3.0`)>>
 * Jakarta Batch 2.0 (`batch-2.0`)
-* Jakarta XML Web Services 3.0 (`xmlWS-3.0`)
 
 These join the Jakarta EE 9 features in link:https://openliberty.io/blog/?search=beta&key=tag[previous Open Liberty betas]:
 
@@ -115,6 +115,35 @@ The following features can be included in your server.xml:
 ----
 
 Additional information about the Jakarta Security 2.0 specification can be found link:https://jakarta.ee/specifications/security/2.0/[here].
+
+[#xmlws]
+=== Jakarta XML Web Services 3.0
+
+Jakarta XML Web Services 3.0 is an API that enables applications to create SOAP based Web Services. Support provides the following updated APIs: XML Web Services 3.0, Jakarta Web Services Metadata 3.0, Jakarta SOAP with Attachments 2.0. Support also introduces the `xmlWS-3.0` feature, as well as the Application Client Container support for XML Web Services 3.0 via the `jakartaeeClient-9.0` convenience feature.
+
+The `xmlWS-3.0` feature provides the Jakarta EE 9 XML Web Services 3.0 tools for Top Down and Bottom Up Web Services Creation: `wsgen` and `wsimport`. These can be found in a new location in the Open Liberty image: wlp/bin/xmlWS/. Both commands preform nearly identical to the Jakarta EE 8 tooling, with the exception that the `-target` argument is no longer required.
+
+The implementation of Jakarta XML Web Services 3.0 in Open Liberty is based on Apache CXF 3.4.1. This provides numerous improvements and fixes over the forked version of CXF 2.6.2 in use by the Jakarta EE 8 `jaxws-2.3` feature (Note: Not all CXF 3.4.1 functionality is available in `xmlWS-3.0`, but watch this space for updates.)
+
+To enable the new Jakarta EE 9 XML Web Services 3.0 feature, add the xmlWS-3.0 feature to your server.xml. Here's an example of what the feature configuration looks like:
+
+[source, xml]
+----
+ <featureManager>
+       <feature>xmlWS-3.0</feature>
+ </featureManager>
+----
+
+To run Jakarta XML Web Services on the Application Client Container: Here's an example of what the client.xml configuration looks:
+
+[source, xml]
+----
+ <featureManager>
+       <feature>jakartaeeClient-9.0</feature>
+ </featureManager>
+----
+
+For more information see the link:https://jakarta.ee/specifications/xml-web-services/[Jakarta XML Web Services Specification], and the link:https://cxf.apache.org/docs/34-migration-guide.html[Apache CXF 3.4 Migration Guide].
 
 Enable the Jakarta EE 9 beta features in your app's `server.xml`. You can enable the individual features you want or you can just add the Jakarta EE 9 convenience feature to enable all of the Jakarta EE 9 beta features at once:
 

--- a/posts/2021-01-26-ee9-messaging-security-21002-beta.adoc
+++ b/posts/2021-01-26-ee9-messaging-security-21002-beta.adoc
@@ -141,7 +141,7 @@ To run Jakarta XML Web Services on the Application Client Container: Here's an e
  </featureManager>
 ----
 
-For more information see the link:https://jakarta.ee/specifications/xml-web-services/3.0/[Jakarta XML Web Services Specification], and the link:https://cxf.apache.org/docs/34-migration-guide.html[Apache CXF 3.4 Migration Guide].
+For more information see the link:https://jakarta.ee/specifications/xml-web-services/3.0/[Jakarta XML Web Services Specification].
 
 Enable the Jakarta EE 9 beta features in your app's `server.xml`. You can enable the individual features you want or you can just add the Jakarta EE 9 convenience feature to enable all of the Jakarta EE 9 beta features at once:
 


### PR DESCRIPTION
Adds the Jakarta XML Web Services 3.0 write up to the 21.0.0.1-beta blog.

https://github.com/OpenLiberty/open-liberty/issues/15689

https://blogs-draft-openlibertyio.mybluemix.net/blog/2021/01/26/ee9-messaging-security-21002-beta.html