### PR TITLE
Changes to title of beta post

### DIFF
--- a/posts/2021-02-19-mpcontextpropagation-requesttiming-21003-beta.adoc
+++ b/posts/2021-02-19-mpcontextpropagation-requesttiming-21003-beta.adoc
@@ -221,7 +221,7 @@ This Open Liberty beta introduces the following Jakarta EE 9 feature which now p
 
 * <<mail, JakartaMail (`mail-2.0`)>>
 
-This feature joins the Jakarta EE 9 features in link:https://openliberty.io/blog/2021/01/26/ee9-messaging-security-21002-beta.html#jakarta[Open Liberty 21.0.0.2-beta Jakarta functions ]
+This feature joins the Jakarta EE 9 features in link:https://openliberty.io/blog/2021/01/26/ee9-messaging-security-21002-beta.html#jakarta[Open Liberty 21.0.0.2-beta Jakarta functions].
 
 [#mail]
 === JakartaMail

--- a/posts/2021-02-19-mpcontextpropagation-requesttiming-21003-beta.adoc
+++ b/posts/2021-02-19-mpcontextpropagation-requesttiming-21003-beta.adoc
@@ -1,15 +1,15 @@
 ---
 layout: post
-title: "MicroProfile Context Propagation 1.2 and RequestTiming 1.0 and enhancments to App Manager configuration and Liberty connection management in Open Liberty 21.0.0.3-beta"
+title: "RequestTiming 1.0, MicroProfile Context Propagation 1.2, enhancments to App Manager configuration and Liberty connection management in Open Liberty 21.0.0.3-beta"
 categories: blog
 author_picture: https://avatars3.githubusercontent.com/jakub-pomykala
 author_github: https://github.com/jakub-pomykala
-seo-title: MicroProfile Context Propagation 1.2 and RequestTiming 1.0 and enhancments to App Manager configuration and Liberty connection management in Open Liberty 21.0.0.3-beta - OpenLiberty.io
+seo-title: RequestTiming 1.0, MicroProfile Context Propagation 1.2, enhancments to App Manager configuration and Liberty connection management in Open Liberty 21.0.0.3-beta - OpenLiberty.io
 seo-description: Open Liberty 21.0.0.3-beta contains four All Beta features (new `expandLocation` property for App Manager configuration, Ability to control whether thread dumps are collected when a hung request is detected in the Request Timing feature (RequestTiming 1.0), MicroProfile Context Propagation 1.2 and Automatic Cleanup of Leaked Connections) and one feature in Jakarta EE 9 (JakartaMail).
 blog_description: Open Liberty 21.0.0.3-beta contains four All Beta features (new `expandLocation` property for App Manager configuration, Ability to control whether thread dumps are collected when a hung request is detected in the Request Timing feature (RequestTiming 1.0), MicroProfile Context Propagation 1.2 and Automatic Cleanup of Leaked Connections) and one feature in Jakarta EE 9 (JakartaMail). Also in 21.0.0.3-beta the link:https://github.com/OpenLiberty/open-liberty/issues/15649[issue in MicroProfile Fault Tolerance 3.0] from 21.0.0.2-beta has now been resolved meaning that the `mpFaultTolerance-3.0` feature and the `microProfile-4.0` convenience feature can be used in the Open Liberty 21.0.0.3-beta.
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 ---
-= MicroProfile Context Propagation 1.2 and RequestTiming 1.0 and enhancments to App Manager configuration and Liberty connection management in Open Liberty 21.0.0.3-beta
+= RequestTiming 1.0, MicroProfile Context Propagation 1.2, enhancments to App Manager configuration and Liberty connection management in Open Liberty 21.0.0.3-beta
 Jakub Pomykala <https://github.com/jakub-pomykala>
 :imagesdir: /
 :url-prefix:


### PR DESCRIPTION
From "MicroProfile Context Propagation 1.2 and RequestTiming 1.0 and enhancments to App Manager configuration and Liberty connection management in Open Liberty 21.0.0.3-beta" to "RequestTiming 1.0, MicroProfile Context Propagation 1.2, enhancments to App Manager configuration and Liberty connection management in Open Liberty 21.0.0.3-beta"