### PR TITLE
Switch gradle group to `compileOnly`

### DIFF
--- a/posts/2021-03-24-whats-new-in-MP-Rest-Client2.0.adoc
+++ b/posts/2021-03-24-whats-new-in-MP-Rest-Client2.0.adoc
@@ -41,7 +41,7 @@ or, if you use link:{url-prefix}/guides/gradle-intro.html[Gradle]:
 [source,gradle]
 ----
 dependencies {
-    mpRestClient group: 'org.eclipse.microprofile.rest.client', name: 'microprofile-rest-client-api', version: '2.0'
+    compileOnly group: 'org.eclipse.microprofile.rest.client', name: 'microprofile-rest-client-api', version: '2.0'
 }
 ----
 


### PR DESCRIPTION
Fixed minor bug discovered by @Joseph-Cass - the Gradle group should be `compileOnly` to avoid pulling the MicroProfile Rest Client APIs into the application when they are provided by the Liberty server.