### PR TITLE
Cleanup metadata in standalone MP Rest Client 2.0 blog post

### DIFF
--- a/posts/2021-03-24-whats-new-in-MP-Rest-Client2.0.adoc
+++ b/posts/2021-03-24-whats-new-in-MP-Rest-Client2.0.adoc
@@ -5,10 +5,9 @@ categories: blog
 author_picture: https://avatars3.githubusercontent.com/andymc12
 author_github: https://github.com/andymc12
 seo-title: MicroProfile Rest Client 2.0 - First Look - OpenLiberty.io
-seo-description: This post describes the new features available in MicroProfile Rest Client 2.0 and how to use
-them.
-blog_description: "This post describes the new features available in MicroProfile Rest Client 2.0 and how to use
-them."
+seo-description: This post describes the new features available in MicroProfile Rest Client 2.0 and how to use them.
+blog_description: "This post describes the new features available in MicroProfile Rest Client 2.0 and how to use them."
+open-graph-image: https://openliberty.io/img/twitter_card.jpg
 ---
 = MicroProfile Rest Client 2.0 - First Look
 Andy McCright <https://github.com/andymc12>


### PR DESCRIPTION
Adding open-graph-image metadata and putting the seo-description an blog-description fields on one line each.  Hopefully this will fix the messed up author image issue.