### PR TITLE
21003 anchor links

### DIFF
--- a/posts/2021-03-19-microprofile40-open-liberty-21003.adoc
+++ b/posts/2021-03-19-microprofile40-open-liberty-21003.adoc
@@ -15,32 +15,31 @@ Emily Jiang <https://github.com/Emily-Jiang>
 :url-about: /
 
 The latest release of link:https://github.com/eclipse/microprofile/releases/tag/4.0.1[MicroProfile 4.0] aligns with link:https://jakarta.ee/release/8/[Jakarta EE 8]. There are many new and exciting features introduced in MicroProfile 4.0. In this post, we'll
-take a look at all of the MicroProfile 4.0 updated features and then show you how to use them in Open Liberty. 
+take a look at all of the MicroProfile 4.0 updated features and then show you how to use them in Open Liberty.
 
 == What's New In MicroProfile 4.0?
 The full list of MicroProfile 4.0 specification includes the updates from Jakarta EE 8 and the MicroProfile specification updates.
 
 === Jakarta EE 8 Specification updates:
 
-. link:https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html[Jakarta Contexts and Dependency Injection 2.0]
-. link:https://jakarta.ee/specifications/annotations/1.3/annotations-spec-1.3.html[Jakarta Annotations 1.3]
-. link:https://jakarta.ee/specifications/restful-ws/2.1/restful-ws-spec-2.1.html[Jakarta RESTful Web Services 2.1]
-. link:https://jakarta.ee/specifications/jsonb/1.0/jsonb-spec-1.0.html[Jakarta JSON Binding 1.0]
-. link:https://jakarta.ee/specifications/jsonp/1.1/jsonp-spec-1.1.html[Jakarta JSON Processing 1.1]
+- link:https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html[Jakarta Contexts and Dependency Injection 2.0]
+- link:https://jakarta.ee/specifications/annotations/1.3/annotations-spec-1.3.html[Jakarta Annotations 1.3]
+- link:https://jakarta.ee/specifications/restful-ws/2.1/restful-ws-spec-2.1.html[Jakarta RESTful Web Services 2.1]
+- link:https://jakarta.ee/specifications/jsonb/1.0/jsonb-spec-1.0.html[Jakarta JSON Binding 1.0]
+- link:https://jakarta.ee/specifications/jsonp/1.1/jsonp-spec-1.1.html[Jakarta JSON Processing 1.1]
 
 Open Liberty releases (19.0.0.6 and onwards) are link:https://jakarta.ee/compatibility/#tab-8[Jakarta EE 8 compatible]. Jakarta EE 8 features are functionally identical to their Java EE 8 counterparts with the only difference being the maven coordinates. The alignment with Jakarta EE 8 demonstrates MicroProfile welcomes the new releases from Jakarta EE and tries to keep up with the new releases from Jakarta EE.
 
 === MicroProfile Component Specification Updates:
 
-. link:https://github.com/eclipse/microprofile-config/releases/tag/2.0[MicroProfile Config 2.0]
-
-. link:https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/3.0[MicroProfile Fault Tolerance 3.0]
-. link:https://github.com/eclipse/microprofile-health/releases/tag/3.0[MicroProfile Health 3.0]
-. link:https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.2[MicroProfile JWT Authentication 1.2]
-. link:https://github.com/eclipse/microprofile-metrics/releases/tag/3.0[MicroProfile Metrics 3.0]
-. link:https://github.com/eclipse/microprofile-open-api/releases/tag/2.0[MicroProfile OpenAPI 2.0]
-. link:https://github.com/eclipse/microprofile-opentracing/releases/tag/2.0[MicroProfile OpenTracing 2.0]
-. link:https://github.com/eclipse/microprofile-rest-client/releases/tag/2.0[MicroProfile Rest Client 2.0]
+- link:https://github.com/eclipse/microprofile-config/releases/tag/2.0[MicroProfile Config 2.0]
+- link:https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/3.0[MicroProfile Fault Tolerance 3.0]
+- link:https://github.com/eclipse/microprofile-health/releases/tag/3.0[MicroProfile Health 3.0]
+- link:https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.2[MicroProfile JWT Authentication 1.2]
+- link:https://github.com/eclipse/microprofile-metrics/releases/tag/3.0[MicroProfile Metrics 3.0]
+- link:https://github.com/eclipse/microprofile-open-api/releases/tag/2.0[MicroProfile OpenAPI 2.0]
+- link:https://github.com/eclipse/microprofile-opentracing/releases/tag/2.0[MicroProfile OpenTracing 2.0]
+- link:https://github.com/eclipse/microprofile-rest-client/releases/tag/2.0[MicroProfile Rest Client 2.0]
 
 In the next section, we will go through each MicroProfile Specification and take a further look at their new and exciting features.
 
@@ -89,19 +88,19 @@ Also, make sure to configure your Liberty server with the `microProfile-4.0` fea
 
 That's it! Now that we've got our development and deployment environments set up, it's time to dive into each individual MicroProfile Specification to learn more about these highly anticipated updates!
 
-. <<config-2.0, What's new in MicroProfile Config 2.0>>
-. <<fault-tolerance-3.0, New features in MicroProfile Fault Tolerance 3.0>>
-. <<health-3.0, New changes in MicroProfile Health 3.0>>
-. <<metrics-3.0, What's New in MicroProfile Metrics 3.0>>
-. <<open-tracing-2.0, New updates in  MicroProfile Open Tracing 2.0>>
-. <<open-api-2.0, What's New in MicroProfile Open API 2.0>>
-. <<rest-client-2.0, Awesome features in MicroProfile Rest Client 2.0>>
-. <<jwt-1.2, Must known features in MicroProfile JWT Auth 1.2>>
-. <<summary, Summary>>
+- <<#config,What's new in MicroProfile Config 2.0>>
+- <<#fault-tolerance,New features in MicroProfile Fault Tolerance 3.0>>
+- <<#health,New changes in MicroProfile Health 3.0>>
+- <<#metrics,What's New in MicroProfile Metrics 3.0>>
+- <<#open-tracing,New updates in  MicroProfile Open Tracing 2.0>>
+- <<#open-api,What's New in MicroProfile Open API 2.0>>
+- <<#rest-client,Awesome features in MicroProfile Rest Client 2.0>>
+- <<#jwt,Enhancements in MicroProfile JWT Auth 1.2>>
+- <<#summary, Summary>>
 
 
 
-[#config-2.0]
+[#config]
 == What's New in MicroProfile Config 2.0
 
 Quite a few nice capabilities were provided by MicroProfile Config 2.0, such as Config Profile, Config Properties, ConfigValue support, and more.
@@ -110,7 +109,7 @@ Open Liberty's MicroProfile Config 2.0 feature is based on link:https://github.c
 
 Watch this space for a new blog post dedicated to MicroProfile Config 2.0.
 
-[#fault-tolerance-3.0]
+[#fault-tolerance]
 == What's New in MicroProfile Fault Tolerance 3.0
 
 MicroProfile Fault Tolerance allows you to easily apply strategies for mitigating failure to your code. It provides annotations that you can add to methods to use bulkhead, circuit breaker, retry, timeout and fallback strategies.
@@ -136,7 +135,7 @@ The specification now requires that circuit breakers and bulkheads are singleton
 
 Get an introduction to MicroProfile Fault Tolerance with the Open Liberty guides link:{url-prefix}/guides/retry-timeout.html[Failing fast and recovering from errors] and link:{url-prefix}/guides/circuit-breaker.html[Preventing repeated failed calls to microservices].
 
-==== Try it now 
+==== Try it now
 
 Enable Fault Tolerance 3.0 and CDI in the `server.xml`, along with any other features you're using.
 
@@ -158,7 +157,7 @@ For more information:
 
 
 
-[#metrics-3.0]
+[#metrics]
 == What's New in MicroProfile Metrics 3.0
 
 MicroProfile Metrics 3.0 introduces new metric values for the existing SimpleTimer and Timer metrics. Additionally a new REST metric is introduced for better monitoring and handling of unmapped exceptions. Manual configuration for re-usability has been removed. A notable change to the MicroProfile Metrics programming model regarding CDI Producers has been made. Lastly a medley of API improvements and refactoring have been added in this release.
@@ -175,7 +174,7 @@ A new `REST.request.unmappedException.total` metric that is backed by a counter 
 === CDI Producer
 The `@Metrics` annotation will no longer support the method target (i.e it can not be annotated on a method). Additionally, it will not support usage with CDI Producers.
 
-==== Try it now 
+==== Try it now
 
 Enable Metrics 3.0 in the `server.xml`, along with any other features you're using.
 
@@ -192,7 +191,7 @@ More information:
 
 * link:https://download.eclipse.org/microprofile/microprofile-metrics-3.0/microprofile-metrics-spec-3.0.html#release_notes_3_0[Release Notes]
 
-[#health-3.0]
+[#health]
 == New changes in MicroProfile Health 3.0
 
 MicroProfile Health 3.0 enables you to provide your own health check procedures to be invoked by Open Liberty, to verify the health of your microservices.
@@ -201,7 +200,7 @@ MicroProfile Health allows services to report their health, and publish overall 
 
 MicroProfile Health checks its own health by performing necessary self-checks and then reports its overall status by implementing the API provided by MicroProfile Health. A self-check can be a check on anything that the service needs, such as a dependency, a successful connection to an endpoint, a system property, a database connection, or the availability of required resources. MicroProfile offers checks for both liveness and readiness.
 
-In the `mpHealth-3.0` feature for Open Liberty: 
+In the `mpHealth-3.0` feature for Open Liberty:
 
 * The overall default Readiness status was changed to "DOWN", with an empty response until all the deployed application(s) have been started. A new MicroProfile Config property (`mp.health.default.readiness.empty.response=UP`) is introduced to change the overall default Readiness check status to "UP", during application start up, that do not have any user-defined health checks.
 
@@ -249,12 +248,12 @@ More information:
 
 * link:https://download.eclipse.org/microprofile/microprofile-health-3.0/microprofile-health-spec-3.0.html#release_notes_3_0[Release notes]
 
-[#opentracing-2.0]
+[#opentracing]
 == New updates in  MicroProfile Open Tracing 2.0
 
 MicroProfile OpenTracing 2.0 can be used to profile and monitor applications built using microservice architecture.
 
-MicroProfile OpenTracing 2.0 has upgraded the OpenTracing API to version 0.33.0.  This allows the 
+MicroProfile OpenTracing 2.0 has upgraded the OpenTracing API to version 0.33.0.  This allows the
 use of tracing backends and their libraries that are built on OpenTracing API 0.33.0.
 
 ==== Try it now
@@ -288,14 +287,14 @@ For Jaeger, add the following maven dependencies in the application's pom.xml.
 </dependency>
 ----
 
-You can find out more about about configuring Jaeger settings using environment variables by looking 
+You can find out more about about configuring Jaeger settings using environment variables by looking
 at link:https://github.com/jaegertracing/jaeger-client-java/blob/v1.2.0/jaeger-core/README.md[jaeger-client-java readme].
 
 We also have an Open Liberty guide on enabling distributed tracing using Jaeger which you can access link:https://openliberty.io/guides/microprofile-opentracing-jaeger.html[here].
 
 For the `JAEGER_PASSWORD` environment variable, the password can be encoded using the `securityUtility` command.
 
-Depending on Jaeger’s sampling settings `JAEGER_SAMPLER_TYPE` and `JAEGER_SAMPLER_PARAM`, 
+Depending on Jaeger’s sampling settings `JAEGER_SAMPLER_TYPE` and `JAEGER_SAMPLER_PARAM`,
 Jaeger may not report every span created by the applications.
 
 For Zipkin, take a look at the link:https://github.com/WASdev/sample.opentracing.zipkintracer[sample project] to see how to implement a tracer for Liberty.
@@ -319,8 +318,8 @@ More information:
 
 * link:https://download.eclipse.org/microprofile/microprofile-opentracing-2.0/microprofile-opentracing-spec-2.0.html#_release_2_0[Release notes]
 
-[#open-api-2.0]
-== What's New in MicroProfile Open API 2.0 
+[#open-api]
+== What's New in MicroProfile Open API 2.0
 
 MicroProfile OpenAPI 2.0 builds on top of the OpenAPI v3 specification. The link:https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md[OpenAPI v3 specification] defines a standard, language-agnostic, interface for describing REST APIs which allows documentation to be generated from the APIs themselves. The link:https://download.eclipse.org/microprofile/microprofile-open-api-2.0/microprofile-openapi-spec-2.0.html[MicroProfile OpenAPI specification] provides a unified Java API for the OpenAPI v3 specification which allows Java developers to generate OpenAPI v3 documents from their JAX-RS applications.
 MicroProfile OpenAPI 2.0 introduces some new annotations that simplify the process of generating OpenAPI documentation for your REST APIs. It also introduces a new MicroProfile Config property prefix that can be used to define the schema for Java classes that you do not have the source code for.
@@ -366,7 +365,7 @@ With the introduction of the `@RequestBodySchema` annotation, this can be simpli
 
 [source, java]
 ----
-@RequestBodySchema(MyRequestObject.class) 
+@RequestBodySchema(MyRequestObject.class)
 ----
 
 [#apiresponseschema]
@@ -425,14 +424,14 @@ For more information:
 * link:https://download.eclipse.org/microprofile/microprofile-open-api-2.0/microprofile-openapi-spec-2.0.html#release_notes_20[Release notes]
 
 
-[#rest-client-2.0]
+[#rest-client]
 == Awesome new features in MicroProfile Rest Client 2.0
 
 MicroProfile REST Client is a type-safe client API enabling rapid development of applications capable of consuming RESTful services. Version 2.0 is the latest update and adds support for HTTP proxy servers, automatically following HTTP redirects, Server Sent Events, and additional configuration options for JSON-B providers and multiple query parameters.
 
 Shortly we will be publishing a dedicated blog post solely on MicroProfile Rest Client 2.0, which will demonstrate all the new features and how to use them.
 
-[#jwt-1.2]
+[#jwt]
 == Enhancements in MicroProfile JWT Auth 1.2
 
 MicroProfile JWT 1.2 simplifies the configuration for managing the validation of the JWT by introducing new MicroProfile Config properties. Enhanced signature algorithm support is added in this Open Liberty implementation.

--- a/posts/2021-03-22-ldap-kerberos-21004beta.adoc
+++ b/posts/2021-03-22-ldap-kerberos-21004beta.adoc
@@ -96,9 +96,9 @@ The following example shows how to configure an LDAP Registry using a keytab and
 <ldapRegistry id="LDAP" realm="SampleLdapADRealm" host="ldap_hostname" port="389" ignoreCase="true" baseDN="DC=example,DC=com" bindAuthMechanism="GSSAPI" krb5Principal="user1@EXAMPLE.COM" ldapType="Custom" />
 ----
 
-For more information on `LdapRegistry`, see the link:https://openliberty.io/docs/latest/reference/feature/ldapRegistry-3.0.html[LDAP User Registry 3.0 feature].
+For more information on `LdapRegistry`, see the link:https://openliberty.io/docs/latest/reference/feature/ldapRegistry-3.0.html[LDAP User Registry documentation].
 
-To enable this new beta function in your app, pull the All Beta Features package and add the LDAP Registry 3.0 feature to your `server.xml` file:
+To enable this new beta function in your app, pull the All Beta Features package and add the LDAP User Registry 3.0 feature to your `server.xml` file:
 
 [source, xml]
 ----

--- a/posts/2021-03-22-ldap-kerberos-21004beta.adoc
+++ b/posts/2021-03-22-ldap-kerberos-21004beta.adoc
@@ -17,7 +17,7 @@ Austin Bailey <https://github.com/austin0>
 
 Open Liberty 21.0.0.4-beta contains new authentication methods for LDAP connections and the complete suite of Jakarta EE 9 API candidates.
 
-With the release of Open Liberty 21.0.0.3, MicroProfile 4.0 and associated components are promoted to the general availability release. For more information, see the link:[Open Liberty 21.0.0.3 release blog post].
+With the release of Open Liberty 21.0.0.3, MicroProfile 4.0 and associated components are promoted to the general availability release. For more information, see the link:https://openliberty.io/blog/2021/03/19/microprofile-4-21003.html[Open Liberty 21.0.0.3 release blog post].
 
 We have two beta packages for link:{url-about}[Open Liberty]:
 
@@ -30,7 +30,7 @@ If you try either package, <<feedback, let us know what you think>>.
 [#allbeta]
 == All Beta Features package
 
-The  includes the following beta features:
+The All Beta Features package includes the following beta features:
 
 * <<LDAP, LDAP connection support for Kerberos authentication>>
 
@@ -96,7 +96,7 @@ The following example shows how to configure an LDAP Registry using a keytab and
 <ldapRegistry id="LDAP" realm="SampleLdapADRealm" host="ldap_hostname" port="389" ignoreCase="true" baseDN="DC=example,DC=com" bindAuthMechanism="GSSAPI" krb5Principal="user1@EXAMPLE.COM" ldapType="Custom" />
 ----
 
-For more information on `LdapRegistry`, see the link:https://openliberty.io/docs/latest/reference/feature/ldapRegistry-3.0.html[LDAP User Registry documentation].
+For more information on `LdapRegistry`, see the link:https://openliberty.io/docs/latest/reference/feature/ldapRegistry-3.0.html[LDAP User Registry 3.0 feature].
 
 To enable this new beta function in your app, pull the All Beta Features package and add the LDAP Registry 3.0 feature to your `server.xml` file:
 
@@ -163,7 +163,7 @@ Or take a look at our link:{url-prefix}/downloads/#runtime_betas[Downloads page]
 [#jakarta]
 == Jakarta EE 9 Beta Features package
 
-As of the 21.0.0.2-beta release, Open Liberty is the first vendor product to be Jakarta EE Web Profile 9.0 compatible. With the recent 21.0.0.3-beta release, Open Liberty is the first vendor product to be added to the Jakarta EE Platform 9.0 compatibility list.
+As of the 21.0.0.2-beta release, Open Liberty is the first vendor product to be Jakarta EE Web Profile 9.0 compatible. With the recent 21.0.0.3-beta release, Open Liberty is the first vendor product to be added to the link:https://jakarta.ee/compatibility/#tab-9[Jakarta EE Platform 9.0 compatibility list].
 
 This Open Liberty beta release comes complete with all of the previously released Jakarta EE9 API candidates:
 


### PR DESCRIPTION
Hi @austin0 -  I noticed today that the internal anchor links in the gA release blog aren't working. I think this is because there are periods in the anchor syntax, ie `config-2.0`. I removed the version numbers from the anchors and they seem to work fine locally. I also changed the ordered lists to unordered lists because lists dont actually consist of numbered steps.

However- it seems I can't merge the changes to draft because there are a bunch of conflicts  between draft and prod.

Looks as though at least some of them are coming from the beta post that @jakub-pomykala edited  recently, which looks as though it might have some changes in prod that aren't in draft