### PR TITLE
Fixing link for MP Config 2.0 blog post

### DIFF
--- a/posts/2021-03-31-microprofile-config-2.0.adoc
+++ b/posts/2021-03-31-microprofile-config-2.0.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "MicroProfile Config 2.0"
-categories: blog, MicroProfile
+categories: blog
 author_picture: https://avatars3.githubusercontent.com/Joseph-Cass
 author_github: https://github.com/Joseph-Cass
 seo-title: MicroProfile Config 2.0 - OpenLiberty.io


### PR DESCRIPTION
Link was previously "https://openliberty.io/blog,/microprofile/2021/03/31/microprofile-config-2.0.html". Now it will be "https://openliberty.io/blog/2021/03/31/microprofile-config-2.0.html"