### PR TITLE
Add redirect for MPConfig 2.0

### DIFF
--- a/blog-redirects.properties
+++ b/blog-redirects.properties
@@ -9,3 +9,4 @@
 /blog/2019/05/24/testing-database-connections-REST-APIs.html=/blog/2019/09/13/testing-database-connections-REST-APIs.html
 /blog/2019/09/13/microprofile-reactive-messsaging-19009.html=/blog/2019/09/13/microprofile-reactive-messaging-19009.html
 /blog/2019/11/07/ibm-red-hat-support-open-liberty.html=/blog/?search=OpenShift
+/blog,/microprofile/2021/03/31/microprofile-config-2.0.html=/blog/2021/03/31/microprofile-config-2.0.html


### PR DESCRIPTION
Redirect (https://openliberty.io/blog,/microprofile/2021/03/31/microprofile-config-2.0.html) works on draft