### PR TITLE
Remove Java 16 section from OL 21.0.0.5 GA blog

### DIFF
--- a/posts/2021-05-14-ldap-multipart-21005.adoc
+++ b/posts/2021-05-14-ldap-multipart-21005.adoc
@@ -25,7 +25,6 @@ In link:{url-about}[Open Liberty] 21.0.0.5:
 
 * <<ldap, LDAP connection support for Kerberos authentication>>
 * <<multi, Build multipart payloads for your JAX-RS client and services>>
-* <<java16, Support for Java SE 16>>
 
 // end::intro[]
 View the list of fixed bugs in <<bugs, 21.0.0.5>>.
@@ -182,28 +181,6 @@ Response response = client.target(BLOG_SITE_URI)
 For more information vist:
 
 * link:https://tools.ietf.org/html/rfc7578[multipart/form-data RFC 7578]
-
-[#java16]
-== Support for Java SE 16
-
-Any official Java SE 16 release from link:https://adoptopenjdk.net?variant=openjdk16&jvmVariant=openj9[AdoptOpenJDK], link:https://jdk.java.net/16/[Oracle], or other OpenJDK vendor will work with Open Liberty. Java SE 16 is not a long-term supported release, with standard support scheduled to end in September 2021.
-
-Keep in mind, Eclipse OpenJ9 link:{url-prefix}/blog/2019/10/30/faster-startup-open-liberty.html[typically offers faster startup times] than Hotspot.
-
-The primary features added in this release include:
-
-* link:https://openjdk.java.net/jeps/396[JEP 396] Strongly Encapsulate JDK Internals by Default
-* link:https://openjdk.java.net/jeps/395[JEP 395] Records
-* link:https://openjdk.java.net/jeps/386[JEP 386] Alpine Linux Port
-* link:https://openjdk.java.net/jeps/376[JEP 376] Concurrent Thread-Stack Processing
-* link:https://openjdk.java.net/jeps/397[JEP 397] Sealed Classes (Second Preview)
-* link:https://openjdk.java.net/jeps/338[JEP 338] Vector API (Incubator)
-
-For more information on downloading a version of Java 16, see link:https://adoptopenjdk.net/index.html?variant=openjdk16&jvmVariant=openj9[AdoptOpenJDK.net], link:https://www.eclipse.org/openj9/[Eclipse.org] or link:https://openjdk.java.net/groups/hotspot[OpenJDK.java.net].
-
-For working with the `server.env` file in Open Liberty, see the `Configuration Files` section of the Open Liberty link:{url-prefix}/docs/latest/reference/config/server-configuration-overview.html[Server Configuration Overview documentation].
-
-For more information on new features available in Java 16, see link:https://openjdk.java.net/projects/jdk/16/[OpenJDK].
 
 //end::features[]
 


### PR DESCRIPTION
Fix to remove the Java 16 section, intended to be re-included at a later date.