### PR TITLE
OL stack gradle support blog draft publish date update.

### DIFF
--- a/posts/2021-09-14-open-liberty-stack-gradle.adoc
+++ b/posts/2021-09-14-open-liberty-stack-gradle.adoc
@@ -5,8 +5,8 @@ categories: blog
 author_picture: https://avatars3.githubusercontent.com/mezarin
 author_github: https://github.com/mezarin
 seo-title: Cloud-native development of Gradle-built applications with the Open Liberty devfile stack - OpenLiberty.io
-seo-description: Get true-to-production development of Gradle built applications directly in a Kubernetes cluster
-blog_description: "Get true-to-production development of Gradle built applications directly in a Kubernetes cluster"
+seo-description: Get true-to-production development of Gradle-built applications directly in a Kubernetes cluster
+blog_description: "Get true-to-production development of Gradle-built applications directly in a Kubernetes cluster"
 ---
 = Cloud-native development of Gradle-built applications with the Open Liberty devfile stack
 Edward Mezarina <https://github.com/mezarin>
@@ -106,4 +106,4 @@ Odo will now push any application changes to the cluster automatically without t
 
 - To learn more about odo, see https://odo.dev[odo.dev].
 - For more details about the Open Liberty devfile stack, open an issue, or create a pull request, go to the https://github.com/OpenLiberty/application-stack[Open Liberty Application Stack GitHub repo]. For questions or comments, contact us on link:https://gitter.im/OpenLiberty/developer-experience[Gitter].
-- For instructions on how to deploy Maven built applications using the Open Liberty devfile stack, see https://openliberty.io/blog/2021/01/20/open-liberty-devfile-stack.html[Develop cloud-native Java applications directly in OpenShift with Open Liberty and odo]
+- For instructions on how to deploy Maven-built applications using the Open Liberty devfile stack, see https://openliberty.io/blog/2021/01/20/open-liberty-devfile-stack.html[Develop cloud-native Java applications directly in OpenShift with Open Liberty and odo]


### PR DESCRIPTION
Parent issue: #1611
Had a chat with Grace J. The publishing date for this is 9/14/21 Changing the blog accordingly.