### PR TITLE
update default value in beta blog

### DIFF
--- a/posts/2021-11-02-microprofile-jakarta-210012-beta.adoc
+++ b/posts/2021-11-02-microprofile-jakarta-210012-beta.adoc
@@ -50,7 +50,7 @@ You can enable the MicroProfile JSON Web Token 2.0 feature by using the `mpJwt-2
 
 [source, xml]
 ----
-<featureManager>              
+<featureManager>
   <feature>mpJwt-2.0</feature>
 </featureManager>
 ----
@@ -73,7 +73,7 @@ You can enable the MicroProfile Health 4.0 feature by using the `mpHealth-4.0` f
 
 [source, xml]
 ----
-<featureManager>              
+<featureManager>
   <feature>mpHealth-4.0</feature>
 </featureManager>
 ----
@@ -93,7 +93,7 @@ You can enable the MicroProfile Metrics 4.0 feature by using the `mpMetrics-4.0`
 
 [source, xml]
 ----
-<featureManager>              
+<featureManager>
   <feature>mpMetrics-4.0</feature>
 </featureManager>
 ----
@@ -110,7 +110,7 @@ You can enable the MicroProfile Open API 3.0 feature by using the `mpOpenAPI-3.0
 
 [source, xml]
 ----
-<featureManager>              
+<featureManager>
   <feature>mpOpenAPI-3.0</feature>
 </featureManager>
 ----
@@ -127,7 +127,7 @@ You can enable the MicroProfile Fault Tolerance 4.0 feature by using the `mpFaul
 
 [source, xml]
 ----
-<featureManager>              
+<featureManager>
   <feature>mpFaultTolerance-4.0</feature>
 </featureManager>
 ----
@@ -144,7 +144,7 @@ You can enable the MicroProfile Config 3.0 feature by using the `mpConfig-3.0` f
 
 [source, xml]
 ----
-<featureManager>              
+<featureManager>
   <feature>mpConfig-3.0</feature>
 </featureManager>
 ----
@@ -173,24 +173,24 @@ The following MP Config properties can be used to configure this feature:
 |Name               |Description              |Default               |Values
 
 |`mp.openapi.extensions.liberty.merged.include` | List of modules which should be included in the merged OpenAPI documentation | `first`
-a| 
+a|
 * `all` (to include all applications)
 * `first` (to include only the first web module deployed, matching the previous behavior)
 * comma-separated list of `<appname>` (to include individual applications) and `<appname>/<modulename>` (to include individual modules within an EAR)
 |`mp.openapi.extensions.liberty.merged.exclude`
-a| 
+a|
 * List of modules which should be excluded from the merged OpenAPI documentation
 * Takes priority over the list of included modules
 | `none`
 a|
-* none (to exclude nothing)
+* `none` (to exclude nothing)
 * comma-separated list of <appname> (to exclude individual applications) and <appname>/<modulename> (to exclude individual modules within an EAR)
-|`mp.openapi.extensions.liberty.merged.info`| This property sets the info section of the final Open API document | `none`
+|`mp.openapi.extensions.liberty.merged.info`| This property sets the info section of the final Open API document | N/A 
 a|
 * The value must be a valid OpenAPI info section in JSON format. If this property is set, the info section in the final OpenAPI document is replaced with the value of the property. This replacement is made after any merging is completed.
 |===
 
-=== Try it now 
+=== Try it now
 
 To try out these features, just update your build tools to pull the Open Liberty All Beta Features package instead of the main release. The beta works with Java SE 17, Java SE 11, or Java SE 8.
 
@@ -220,8 +220,8 @@ Or take a look at our link:{url-prefix}/downloads/#runtime_betas[Downloads page]
 [#jakarta]
 == Jakarta EE 9 Beta Features package
 
-Open Liberty is the first vendor product to be Jakarta EE Web Profile 9.0 compatible since the 21.0.0.2-beta release. Open Liberty is also the first vendor product to be added to the link:https://jakarta.ee/compatibility/#tab-9[Jakarta EE Platform 9.0 compatability list], with the release of 21.0.0.3-beta. 
-Open Liberty 21.0.0.6-beta further expanded on this compatability by including new Jakarta EE9 supporting features, and 21.0.0.12-beta offers the same compatability with Jakarta EE9 with performance enhancements. 
+Open Liberty is the first vendor product to be Jakarta EE Web Profile 9.0 compatible since the 21.0.0.2-beta release. Open Liberty is also the first vendor product to be added to the link:https://jakarta.ee/compatibility/#tab-9[Jakarta EE Platform 9.0 compatability list], with the release of 21.0.0.3-beta.
+Open Liberty 21.0.0.6-beta further expanded on this compatability by including new Jakarta EE9 supporting features, and 21.0.0.12-beta offers the same compatability with Jakarta EE9 with performance enhancements.
 
 Enable the Jakarta EE 9 beta features in your app's `server.xml`. You can enable the individual features you want or you can just add the Jakarta EE 9 convenience feature to enable all of the Jakarta EE 9 beta features at once:
 
@@ -273,5 +273,3 @@ Or take a look at our link:{url-prefix}/downloads/#runtime_betas[Downloads page]
 == Your feedback is welcomed
 
 Let us know what you think on link:https://groups.io/g/openliberty[our mailing list]. If you hit a problem, link:https://stackoverflow.com/questions/tagged/open-liberty[post a question on StackOverflow]. If you hit a bug, link:https://github.com/OpenLiberty/open-liberty/issues[please raise an issue].
-
-


### PR DESCRIPTION
it might be confusing to say the default value for `mp.openapi.extensions.liberty.merged.info` is "none", because the actual default value for `mp.openapi.extensions.liberty.merged.exclude` is `none`. So, in the table "none" is being used in two different ways, the first time as an actual value, then again to say that there is no default value, which is potentially confusing. This PR updates the table to use "N/A" instead of "none" for `mp.openapi.extensions.liberty.merged.info` 