### PR TITLE
Update blog author picture

### DIFF
--- a/posts/2018-11-09-prevent-message-log-rotating.adoc
+++ b/posts/2018-11-09-prevent-message-log-rotating.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: Maximise log history on Open Liberty in production
 categories: blog
-author_picture: https://avatars3.githubusercontent.com/u/28316667
+author_picture: https://avatars.githubusercontent.com/u/6618433
 author_github: https://github.com/kgibm
 seo-title: Maximise log history on Open Liberty in production - OpenLiberty.io.
 seo-description: In development, starting a new log file each time the server restarts is great but, in production, you can now disable this behaviour so that you can retain more history in your logs.


### PR DESCRIPTION
- The author originally had a GitHub stock photo. The author now has a
personal picture, so switch from the OpenLiberty logo to the author's
GitHub picture.

https://openliberty.io/blog/2018/11/09/prevent-message-log-rotating.html
