### PR TITLE
Update 22.0.0.3 blog with CVE list, and add CVE list to release template

### DIFF
--- a/posts/2022-03-15-sql-retries-22003.adoc
+++ b/posts/2022-03-15-sql-retries-22003.adoc
@@ -157,6 +157,7 @@ A long running thread was added in 22.0.0.1 to gather CPU statistics. It was cre
 |22.0.0.3
 |Affects the feature:openapi-3.1[], feature:mpOpenAPI-1.0[], feature:mpOpenAPI-1.1[] and feature:mpOpenAPI-2.0[] features
 |===
+For a list of past security vulnerability fixes, reference the link:{url-prefix}/docs/latest/security-vulnerabilities.html[Security vulnerability (CVE) list].
 
 [#guides]
 == New and updated guides since the previous release

--- a/posts/2022-03-15-sql-retries-22003.adoc
+++ b/posts/2022-03-15-sql-retries-22003.adoc
@@ -146,15 +146,14 @@ A long running thread was added in 22.0.0.1 to gather CPU statistics. It was cre
 
 [#CVEs]
 == Security vulnerability (CVE) fixes in this release
-[cols="6*"]
+[cols="5*"]
 |===
-|CVE |CVSS Score |Vulnerability Assessment |Versions Affected |Version Fixed |Notes
+|CVE |CVSS Score |Vulnerability Assessment |Versions Affected |Notes
 
 |http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-39038[CVE-2021-39038]
 |4.4
 |Clickjacking vulnerability
 |17.0.0.3 - 22.0.0.2
-|22.0.0.3
 |Affects the link:{url-prefix}/docs/latest/reference/feature/openapi-3.1.html[openapi-3.1], link:{url-prefix}/docs/latest/reference/feature/mpOpenAPI-1.0.html[mpOpenAPI-1.0], link:{url-prefix}/docs/latest/reference/feature/mpOpenAPI-1.1.html[mpOpenAPI-1.1] and link:{url-prefix}/docs/latest/reference/feature/mpOpenAPI-2.0.html[mpOpenAPI-2.0] features.
 |===
 For a list of past security vulnerability fixes, reference the link:{url-prefix}/docs/latest/security-vulnerabilities.html[Security vulnerability (CVE) list].

--- a/posts/2022-03-15-sql-retries-22003.adoc
+++ b/posts/2022-03-15-sql-retries-22003.adoc
@@ -155,7 +155,7 @@ A long running thread was added in 22.0.0.1 to gather CPU statistics. It was cre
 |Clickjacking vulnerability
 |17.0.0.3 - 22.0.0.2
 |22.0.0.3
-|Affects the feature:openapi-3.1[], feature:mpOpenAPI-1.0[], feature:mpOpenAPI-1.1[] and feature:mpOpenAPI-2.0[] features
+|Affects the link:{url-prefix}/docs/latest/reference/feature/openapi-3.1.html[openapi-3.1], link:{url-prefix}/docs/latest/reference/feature/mpOpenAPI-1.0.html[mpOpenAPI-1.0], link:{url-prefix}/docs/latest/reference/feature/mpOpenAPI-1.1.html[mpOpenAPI-1.1] and link:{url-prefix}/docs/latest/reference/feature/mpOpenAPI-2.0.html[mpOpenAPI-2.0] features.
 |===
 For a list of past security vulnerability fixes, reference the link:{url-prefix}/docs/latest/security-vulnerabilities.html[Security vulnerability (CVE) list].
 

--- a/posts/2022-03-15-sql-retries-22003.adoc
+++ b/posts/2022-03-15-sql-retries-22003.adoc
@@ -23,6 +23,7 @@ In link:{url-about}[Open Liberty] 22.0.0.3:
 
 * <<sql, Allow SQL Operations to be retried in transaction recovery logs>>
 * <<bugs, Notable bug fixes>>
+* <<CVEs, Security Vulnerability (CVE) Fixes>>
 
 Along with the new features and functions added to the runtime, we’ve also made <<guides, updates to our guides>>.
 
@@ -142,6 +143,20 @@ Previously, a user would experience slower startup (around 4 or 5 seconds) if `m
 * link:https://github.com/OpenLiberty/open-liberty/issues/20206[Servers stop can fail in products that embed Liberty]
 +
 A long running thread was added in 22.0.0.1 to gather CPU statistics. It was created as a non-daemon thread. This caused problems with stopping the server in products that embed Liberty and prevent the JVM from stopping until all non-daemon threads have exited. The server should stop cleanly. This problem was fixed by running the `CpuInfo` thread as a daemon.
+
+[#CVEs]
+== Security vulnerability (CVE) fixes in this release
+[cols="6*"]
+|===
+|CVE |CVSS Score |Vulnerability Assessment |Versions Affected |Version Fixed |Notes
+
+|http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-39038[CVE-2021-39038]
+|4.4
+|Clickjacking vulnerability
+|17.0.0.3 - 22.0.0.2
+|22.0.0.3
+|Affects the feature:openapi-3.1[], feature:mpOpenAPI-1.0[], feature:mpOpenAPI-1.1[] and feature:mpOpenAPI-2.0[] features
+|===
 
 [#guides]
 == New and updated guides since the previous release

--- a/templates/ga-release-post.adoc
+++ b/templates/ga-release-post.adoc
@@ -67,6 +67,7 @@ In link:{url-about}[Open Liberty] RELEASE_VERSION:
 ** <<SUB_TAG_1, SUB_FEATURE_1_HEADING>>
 ** <<SUB_TAG_2, SUB_FEATURE_2_HEADING>>
 * <<TAG_3, FEATURE_3_HEADING>>
+* <<CVEs, Security Vulnerability (CVE) Fixes>>
 * <<bugs, Notable bug fixes>>
 
 
@@ -207,6 +208,27 @@ For more details, check the LINK[LINK_DESCRIPTION].
 // Replace LINK with the link for extra information given for the feature
 // Replace LINK_DESCRIPTION with a readable description of the information
 // // // // // // // //
+
+[#CVEs]
+== Security vulnerability (CVE) fixes in this release
+[cols="6*"]
+|===
+|CVE |CVSS Score |Vulnerability Assessment |Versions Affected |Version Fixed |Notes
+
+|Link[CVE-XXXX-XXXXX]
+|Score
+|vulnerability
+|Affected versions
+|Fixed version
+|Affected Features and other notes
+|===
+// // // // // // // //
+// In the preceding section:
+// If there were any CVEs addressed in this release, fill out the table.  For the information, reference https://github.com/OpenLiberty/docs/blob/draft/modules/ROOT/pages/security-vulnerabilities.adoc.  If it has not been updated for this release, reach out to Kristen Clarke or Michal Broz.
+// If there are no CVEs fixed in this release, replace the table with: 
+// "There are no security vulnerability fixes in Open Liberty [RELEASE_VERSION]."
+// // // // // // // //
+
 
 [#bugs]
 == Notable bugs fixed in this release

--- a/templates/ga-release-post.adoc
+++ b/templates/ga-release-post.adoc
@@ -211,15 +211,14 @@ For more details, check the LINK[LINK_DESCRIPTION].
 
 [#CVEs]
 == Security vulnerability (CVE) fixes in this release
-[cols="6*"]
+[cols="5*"]
 |===
-|CVE |CVSS Score |Vulnerability Assessment |Versions Affected |Version Fixed |Notes
+|CVE |CVSS Score |Vulnerability Assessment |Versions Affected |Notes
 
 |Link[CVE-XXXX-XXXXX]
 |Score
 |vulnerability
 |Affected versions
-|Fixed version
 |Affected Features and other notes
 |===
 // // // // // // // //

--- a/templates/ga-release-post.adoc
+++ b/templates/ga-release-post.adoc
@@ -228,6 +228,7 @@ For more details, check the LINK[LINK_DESCRIPTION].
 // If there are no CVEs fixed in this release, replace the table with: 
 // "There are no security vulnerability fixes in Open Liberty [RELEASE_VERSION]."
 // // // // // // // //
+For a list of past security vulnerability fixes, reference the link:{url-prefix}/docs/latest/security-vulnerabilities.html[Security vulnerability (CVE) list].
 
 
 [#bugs]


### PR DESCRIPTION
Looks good on staging: https://blogs-staging-openlibertyio.mybluemix.net/blog/2022/03/15/sql-retries-22003.html#CVEs
![image](https://user-images.githubusercontent.com/3076261/161311619-a7caa35f-eef9-4901-bb4e-970ebc7491f2.png)
