### PR TITLE
Update 2022-06-07-microprofile-graphql-2-22006.adoc

### DIFF
--- a/posts/2022-06-07-microprofile-graphql-2-22006.adoc
+++ b/posts/2022-06-07-microprofile-graphql-2-22006.adoc
@@ -21,7 +21,7 @@ Open Liberty 22.0.0.6 offers MicroProfile GraphQL 2.0, which incorporates Jakart
 
 In link:{url-about}[Open Liberty] 22.0.0.6:
 
-* <<graphql, MicroProfile GraphQL 2.0>>
+* <<graphql, Use Jakarta EE 9.1 dependencies with MicroProfile GraphQL 2.0>>
 * <<db2, Improved Db2 query performance>>
 * <<cve, Security Vulnerability (CVE) Fixes>>
 * <<bugs, Notable bug fixes>>
@@ -65,9 +65,20 @@ Or take a look at our link:{url-prefix}/downloads/[Downloads page].
 image::img/blog/blog_btn_stack.svg[Ask a question on Stack Overflow, align="center"]
 
 [#graphql]
-=== MicroProfile GraphQL 2.0
+=== Use Jakarta EE 9.1 dependencies with MicroProfile GraphQL 2.0
 
-MicroProfile GraphQL 2.0 incorporates Jakarta EE 9.1 dependencies.  This allows developers to continue using the same functionality provided by MP GraphQL 1.0 but with the updated Jakarta features such as link:{url-prefix}/docs/latest/reference/feature/cdi-3.0.html[CDI 3.0], link:{url-prefix}/docs/latest/reference/feature/restfulWS-3.0.html[restfulWS 3.0], link:{url-prefix}/docs/latest/reference/feature/jsonb-2.0.html[JSON-B 2.0], etc. Functionally, version 2.0 behaves the same as 1.0 because it uses the same version of the underlying implementation (link:https://github.com/smallrye/smallrye-graphql[SmallRye GraphQL]).  If you'd like to learn more about MicroProfile GraphQL, check out our link:{url-prefix}/guides/microprofile-graphql.htm[Optimizing REST queries for microservices with GraphQL] guide or see our link:{url-prefix}/docs/latest/microprofile-graphql.html[Build GraphQL applications with MicroProfile GraphQL] doc and our link:{url-prefix}/blog/2020/08/28/graphql-apis-open-liberty-20009.html[blog post on how to use the GraphiQL UI and third-party Client APIs].
+link:https://graphql.org/[GraphQL] is an open source data query and manipulation language for APIs and a runtime that fulfills queries with existing data. You can use a GraphQL service to obtain data from multiple sources (such as APIs, databases, and other services) by making only a single request. The GraphQL service can then collate this data into a single object, which simplifies the data retrieval. This results in faster application load times and lower data transfer costs. GraphQL enables clients to better customize requests to the server. Many enterprise companies use GraphQL, including Atlassian, Coursera, Facebook, GitHub, PayPal, and Twitter.
+
+You can implement GraphQL support for applications that run on Open Liberty by enabling the link:{url-prefix}/docs/latest/reference/feature/mpGraphQL.html[MicroProfile GraphQL feature]. When this feature is enabled, you can define GraphQL endpoints by using annotations, similar to how you create RESTful Web Services (formerly JAX-RS) resources.
+
+MicroProfile GraphQL 2.0 incorporates Jakarta EE 9.1 dependencies. If you have been link:{url-prefix}/blog/2020/06/10/microprofile-graphql-open-liberty.html[using MicroProfile GraphQL 1.0 in your application] running on Open Liberty, you can continue to do so but with the updated Jakarta features such as link:{url-prefix}/docs/latest/reference/feature/cdi-3.0.html[CDI 3.0], link:{url-prefix}/docs/latest/reference/feature/restfulWS-3.0.html[restfulWS 3.0], link:{url-prefix}/docs/latest/reference/feature/jsonb-2.0.html[JSON-B 2.0], etc. Functionally, version 2.0 behaves the same as 1.0 because it uses the same version of the underlying implementation (link:https://github.com/smallrye/smallrye-graphql[SmallRye GraphQL]).
+
+If you'd like to learn more about MicroProfile GraphQL:
+
+- Try it out with our link:{url-prefix}/guides/microprofile-graphql.html[Optimizing REST queries for microservices with GraphQL] guide (available in the cloud or as downloads to your laptop).
+- See our link:{url-prefix}/docs/latest/microprofile-graphql.html[Build GraphQL applications with MicroProfile GraphQL] docs.
+- See our blog post on link:{url-prefix}/blog/2020/08/28/graphql-apis-open-liberty-20009.html[how to use the GraphiQL UI and third-party Client APIs].
+
 
 To enable the MicroProfile GraphQL 2.0 feature, add it to your `server.xml`:
 
@@ -119,7 +130,7 @@ Alternatively, in Liberty 22.0.0.2 and later, you can add the new `<defaultPrope
 </server>
 ----
 
-==== Leveraging parameter binding
+==== Using parameter binding
 In the application, you can take advantage of this feature with JPA JPQL queries and CriteriaBuilder API queries.  
 
 *Example 1:*


### PR DESCRIPTION
Expanded the MicroProfile GraphQL section for standalone-ness to enable us to point to it from elsewhere.
Also replaced "Leveraging" with "Using" - never leveraging.