### PR TITLE
Update 2022-08-04-jakarta-core-profile-22009-beta

### DIFF
--- a/posts/2022-08-04-jakarta-core-profile-22009-beta.adoc
+++ b/posts/2022-08-04-jakarta-core-profile-22009-beta.adoc
@@ -3,8 +3,8 @@ layout: post
 title: "Jakarta EE 10 Core Profile debuts in Open Liberty 22.0.0.9-beta"
 # Do NOT change the categories section
 categories: blog
-author_picture: https://avatars3.githubusercontent.com/reece-nana
-author_github: https://github.com/reece-nana
+author_picture: https://avatars.githubusercontent.com/u/93201294
+author_github: https://github.com/reecenana
 seo-title: Jakarta EE 10 Core Profile debuts in Open Liberty 22.0.0.9-beta - OpenLiberty.io
 seo-description: Open Liberty 22.0.0.9-beta brings you the hot-off-the-press Jakarta EE 10 Core Profile. Jakarta EE 10 is the first release to update the Jakarta EE specifications since Java EE 8 in 2017.  MicroProfile OpenAPI 3.1 and Password Utilities 1.1 are also available in this beta release.
 blog_description: Open Liberty 22.0.0.9-beta brings you the hot-off-the-press Jakarta EE 10 Core Profile. Jakarta EE 10 is the first release to update the Jakarta EE specifications since Java EE 8 in 2017.  MicroProfile OpenAPI 3.1 and Password Utilities 1.1 are also available in this beta release


### PR DESCRIPTION
- Fix profile picture and GitHub profile link

Related to https://github.com/OpenLiberty/blogs/pull/2537

Fixed on `draft` site https://blogs-draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/blog/2022/08/04/jakarta-core-profile-22009-beta.html
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/31117513/188725664-cfec3318-2ca7-4842-8fea-95a139a62caa.png">
<img width="945" alt="image" src="https://user-images.githubusercontent.com/31117513/188725694-ecbb2b4d-958e-43c9-ba84-bc11b71e4856.png">
