### PR TITLE
Mp perf collateral update

### DIFF
--- a/posts/2020-10-21-memory-footprint-throughput.adoc
+++ b/posts/2020-10-21-memory-footprint-throughput.adoc
@@ -35,7 +35,7 @@ Cloud services make the cost and memory footprint correlation abundantly clear.�
 The figure below shows memory footprint comparisons (after startup) for servers running the microservices benchmark link:https://github.com/blueperf[Acme Air Microservices].  We can see in this scenario that Open Liberty uses 1.3x – 2.9x less memory than the other runtimes we tested:
 
 [.img_border_light]
-image::img/blog/perfblog1.png[Memory footprint of Java app servers using Acme Air Microservices application in Docker,width=70%,align="center"]
+image::img/blog/perfblog1a.png[Memory footprint of Java app servers using Acme Air Microservices application in Docker,width=70%,align="center"]
 
 If you've chosen Spring Boot for your application (yes, you can link:{url-prefix}/guides/spring-boot.html[use Spring Boot on Open Liberty]), then our measurements show an approximately 2x memory footprint benefit from link:https://developer.ibm.com/technologies/java/articles/modernize-and-optimize-spring-boot-applications/[running on Open Liberty] rather than Tomcat.  For example, the figure below shows the relative memory usage when running the link:https://github.com/spring-projects/spring-petclinic[Spring Boot Petclinic] application under load with a 4Gb heap:
 


### PR DESCRIPTION
update the first image to perfblog1a.png rather than perfblog1.png.  
The perfblog1a.png image has the updated performance data for the blog post.