### PR TITLE
Add note for appSec feature levels in examples

### DIFF
--- a/posts/2022-10-25-22.0.0.11.adoc
+++ b/posts/2022-10-25-22.0.0.11.adoc
@@ -109,6 +109,8 @@ Distributed security cache support is introduced so that multiple Liberty server
 
 === Configuring a distributed authentication cache
 
+NOTE: The `server.xml` file examples in this section specify the `appSecurity-3.0` feature but you can use any version of the Jakarta Security (Application Security) feature to configure a distributed authentication cache.
+
 Because the creation of a subject might affect performance, Liberty provides an authentication cache to store a subject after an authentication of a user is successful. The authentication cache now can be distributed using a 3rd party JCache provider. The `jCacheLibraryRef` references the library that contains the JCache caching provider implementation.  To configure the distributed authentication cache, use the following server.xml configuration:
 
 [source, xml]

--- a/posts/2022-10-25-22.0.0.11.adoc
+++ b/posts/2022-10-25-22.0.0.11.adoc
@@ -109,7 +109,7 @@ Distributed security cache support is introduced so that multiple Liberty server
 
 === Configuring a distributed authentication cache
 
-NOTE: The `server.xml` file examples in this section specify the `appSecurity-3.0` feature but you can use any version of the Jakarta Security (Application Security) feature to configure a distributed authentication cache.
+The `server.xml` file examples in this section specify the `appSecurity-3.0` feature but you can use any version of the Jakarta Security (Application Security) feature to configure a distributed authentication cache.
 
 Because the creation of a subject might affect performance, Liberty provides an authentication cache to store a subject after an authentication of a user is successful. The authentication cache now can be distributed using a 3rd party JCache provider. The `jCacheLibraryRef` references the library that contains the JCache caching provider implementation.  To configure the distributed authentication cache, use the following server.xml configuration:
 

--- a/posts/2022-10-25-22.0.0.11.adoc
+++ b/posts/2022-10-25-22.0.0.11.adoc
@@ -109,7 +109,7 @@ Distributed security cache support is introduced so that multiple Liberty server
 
 === Configuring a distributed authentication cache
 
-The `server.xml` file examples in this section specify the `appSecurity-3.0` feature but you can use any version of the Jakarta Security (Application Security) feature to configure a distributed authentication cache.
+The `server.xml` file examples in this section specify the `appSecurity-3.0` feature but you can use any version of the link:{url-prefix}/docs/latest/reference/feature/appSecurity.html[Jakarta Security (Application Security) feature] to configure a distributed authentication cache.
 
 Because the creation of a subject might affect performance, Liberty provides an authentication cache to store a subject after an authentication of a user is successful. The authentication cache now can be distributed using a 3rd party JCache provider. The `jCacheLibraryRef` references the library that contains the JCache caching provider implementation.  To configure the distributed authentication cache, use the following server.xml configuration:
 


### PR DESCRIPTION
 based on user feedback, add a brief note to clarify any version of appSec will work for the distributed Auth cache