### PR TITLE
Remove empty `blog-available-in-languages` attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.html
 .DS_STORE
-
+.vscode

--- a/posts/ja/2022-09-01-openliberty-guides-in-japanese.adoc
+++ b/posts/ja/2022-09-01-openliberty-guides-in-japanese.adoc
@@ -9,7 +9,6 @@ seo-title: Open Libertyのガイドを使ってクラウドネイティブのJav
 seo-description: この投稿では、Open Libertyのガイドの概要を説明します。Open Libertyのガイドを使うと、JakartaEEとmicroprofileを使ったクラウドネイティブのJavaアプリケーション開発とKubernetes環境へのデプロイメントを効率的に学ぶことができます。
 blog_description: "この投稿では、Open Libertyのガイドの概要を説明します。Open Libertyのガイドを使うと、JakartaEEとmicroprofileを使ったクラウドネイティブのJavaアプリケーション開発とKubernetes環境へのデプロイメントを効率的に学ぶことができます。"
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
-blog-available-in-languages: []
 additional_authors:
 - name: 田中孝清
   github: https://github.com/takakiyo


### PR DESCRIPTION
The logic for `blog-available-in-languages` changed due to issue https://github.com/OpenLiberty/openliberty.io/issues/2890. The new logic expects a value that is not an `array` but rather a list of `key-value`. 