### PR TITLE
Small touch up on the 22.0.0.10 blog (format only)  

### DIFF
--- a/posts/2022-09-27-22.0.0.10.adoc
+++ b/posts/2022-09-27-22.0.0.10.adoc
@@ -105,7 +105,7 @@ For more information about OpenID Connect Client, refer to the link:https://open
 
 [#CVEs]
 == Security vulnerability (CVE) fixes in this release
-[cols="5*"]
+[cols="6*"]
 |===
 |CVE |CVSS Score |Vulnerability Assessment |Versions Affected |Version Fixed |Notes
 
@@ -169,7 +169,7 @@ Removal of message ID prefixes from the `hideMessage` logging attribute was not 
 + 
 This issue is now resolved and the configuration of the running server is properly updated to no longer hide the messages that were removed from the attribute.
 
-* link:https://github.com/OpenLiberty/open-liberty/issues/22189[https://github.com/OpenLiberty/open-liberty/issues/22189]
+* link:https://github.com/OpenLiberty/open-liberty/issues/22189[Missing NLS strings for allowAuthenticationFailOverToAuthMethod options]
 +
 The `AllowAuthenticationFailOverToAuthMethod` option descriptions all had untranslated NLS constants.  This was due to the constants missing from the NLS file for the metatype.
 +


### PR DESCRIPTION
While translating 22.0.0.10 blog per the local team's suggestion, I found the following. formatting issue. 
Creating this PR while I remember. 
- CVE table title and content is one column off
- One bug fix title is URL while others are the git issue title. 

Current blog
https://openliberty.io/blog/2022/09/27/22.0.0.10.html
After this PR
https://github.com/OpenLiberty/blogs/blob/095b6a1749274a026a6578478b52734e4017df36/posts/2022-09-27-22.0.0.10.adoc
