### PR TITLE
Release post mods laura

### DIFF
--- a/posts/2022-10-27-22.0.0.12-beta.adoc
+++ b/posts/2022-10-27-22.0.0.12-beta.adoc
@@ -38,10 +38,11 @@ The link:{url-about}[Open Liberty] 22.0.0.12-beta includes the following beta fe
 ** <<batch, Improved CDI integration (Jakarta Batch 2.1)>>
 ** <<messaging, Connection factory and destination definition annotations are now repeatable (Jakarta Messaging 3.1)>>
 ** <<xmlws, Jakarta Web Services Metadata (Jakarta XML Web Services 4.0)>>
-* MicroProfile 6:
+* MicroProfile 6.0:
 ** <<jwt, Simplified JWT Validation (MicroProfile JSON Web Token 2.1)>>
 ** <<metrics, User-defined metric registry scopes (MicroProfile Metrics 5.0)>>
 
+For a full list of new and updated MicroProfile 6.0 features in Open Liberty, see the link:{url-prefix}/blog/2022/12/06/22.0.0.13-beta.html#mp6[22.0.0.13-beta post].
 
 
 See also link:{url-prefix}/blog/?search=beta&key=tag[previous Open Liberty beta blog posts].

--- a/posts/2022-12-06-22.0.0.13-beta.adoc
+++ b/posts/2022-12-06-22.0.0.13-beta.adoc
@@ -251,10 +251,10 @@ MicroProfile 6.0 enables applications to use MicroProfile APIs together with Jak
 
 The following specifications in MicroProfile 6.0 release are either new or have some major or minor update when compared to MicroProfile 5.0:
 
-- MicroProfile Telemetry 1.0 (new spec)
-- MicroProfile Metrics 5.0 (major update)
-- MicroProfile OpenAPI 3.1 (minor update)
-- MicroProfile JWT 2.1 (minor update)
+- MicroProfile Telemetry 1.0 (new spec; find out more in the link:{url-prefix}/blog/2022/09/01/java-19-22.0.0.10-beta.html#microprofile[22.0.0.10-beta post])
+- MicroProfile Metrics 5.0 (major update; find out more in the link:{url-prefix}/blog/2022/10/27/22.0.0.12-beta.html#metrics[22.0.0.12-beta post])
+- MicroProfile OpenAPI 3.1 (minor update; find out more in the link:{url-prefix}/blog/2022/08/04/jakarta-core-profile-22009-beta.html#microprofile[22.0.0.9-beta post])
+- MicroProfile JWT 2.1 (minor update; find out more in the link:{url-prefix}/blog/2022/10/27/22.0.0.12-beta.html#jwt[22.0.0.12-beta post])
 
 MicroProfile 6.0 has the following backward incompatible changes compared to MicroProfile 5.0:
 


### PR DESCRIPTION
Add links to 22.0.0.12-beta and 22.0.0.13-beta so that it's easier for readers to find a full list of the MP 6.0 new and updated features in Open Liberty betas:

* The [MP 6.0 announcement blog post](https://microprofile.io/2023/01/10/microprofile-6-0-release/) points to the [22.0.0.13-beta blog post](https://openliberty.io/blog/2022/12/06/22.0.0.13-beta.html), which doesn't currently contain a full list, so I've added links to the relevant previous beta blog posts for each of the four new items.
* The [MP 6.0 compatibility page](https://microprofile.io/compatible/6-0/) links to the [22.0.0.12-beta blog post](https://openliberty.io/blog/2022/10/27/22.0.0.12-beta.html), which also doesn't contain all the info, so I've added a sentence linking to the now-updated MP6 section of the 22.0.0.13-beta post.