### PR TITLE
2862 using paketo buildpack for liberty on azure and google cloud

### DIFF
--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -1,0 +1,111 @@
+---
+layout: post
+title: "Deploy Java applications using the cloud native Paketo Buildpacks on Azure and Google Cloud"
+# Do NOT change the categories section
+categories: blog
+author_picture: https://avatars.githubusercontent.com/u/29545669?v=4
+author_github: https://github.com/kevin-ortega
+seo-title:  Deploy Java applications to Azure and Google Cloud using the Paketo Buildpacks - OpenLiberty.io
+seo-description: Learn to deploy your applications to easily with the Paketo Buildpacks
+blog_description: "Learn to deploy your applications to easily with the Paketo Buildpacks"
+---
+= Deploy Java applications to Azure and Google Cloud using Paketo Buildpacks
+Kevin Ortega <https://github.com/kevin-ortega>
+:imagesdir: /
+:url-prefix:
+:url-about: /
+
+Azure and Google Cloud have built-in support for link:https://buildpacks.io[cloud native buildpacks].  
+You can use link:https://learn.microsoft.com/en-us/azure/container-registry/container-registry-tasks-pack-build[Azure] or link:https://cloud.google.com/docs/buildpacks/build-application[Google Cloud] to easily deploy Java applications by using the link:https://openliberty.io/blog/2022/04/01/cloud-native-liberty-buildpack.html[Paketo Buildpack for Liberty] with your source code or container images.
+
+This post provides instructions on how to use the Paketo Buildpack for Liberty with Azure and Google Cloud. To learn more about using Azure and Google Cloud see their respective documentation.  
+
+== What do you need?
+* An https://azure.microsoft.com/en-us/free/[Azure] or https://cloud.google.com/free/[Google Cloud] Account
+* The link:https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Azure cli] or
+* The link:https://cloud.google.com/sdk/docs/install[gcloud cli]
+* Your application source
+
+To build and deploy container images or create a link:https://buildpacks.io/docs/concepts/components/builder/[custom builder], you'll also need:
+
+* The cloud native buildpack link:https://buildpacks.io/docs/tools/pack/[pack CLI]
+* https://www.docker.com/[Docker] or https://podman.io[Podman]. This post focuses on Docker. For information about using Podman with Paketo, refer to the buildpacks.io documentation for https://buildpacks.io/docs/app-developer-guide/building-on-podman/[Building on Podman]. 
+* An externally accessible container registry that can host your images.
+
+The Paketo Buildpack for Liberty is included in the composite Paketo Buildpack for Java that also includes `tomcat` and `tomee` application servers. Tomcat is the default application server and to use Open Liberty requires a little extra configuration.  The Paketo Buildpack for Java includes the Bellsofit Liberica as the default JVM provider.  To use other JVM providers requires extra configuration.  
+
+You can set the application server that the Paketo Buildpack for Java uses by specifying the `BP_JAVA_APP_SERVER` environment variable and select an alternate JVM provider using a link:https://buildpacks.io/docs/app-developer-guide/using-project-descriptor/[project descriptor]. 
+
+== Let's get started
+
+Create the project descriptior file, `project.toml`, in the application's root source directory. At a minimum, `project.toml` should contain `BP_JAVA_APP_SERVER=liberty` but can contain other environment variables consumed by buildpacks.  To use the alternate and preferred JVM, eclipse openj9, we change the order that the buildpacks run in the project descriptor.   To minimize the size of the application container image, the buildpack by default installs the kernel profile.  You can override the profile using the `BP_LIBERTY_PROFILE` environment variable or use the `BP_LIBERTY_FEATURES` environment variable to install the features required by the application.  
+
+For example, your project descriptor should contain the following content to use the liberty applicaiton server, install eclipse openj9, install the kernel profile and install a set of liberty features:
+```
+[[build.env]]
+    name = "BP_JAVA_APP_SERVER"
+    value = "liberty"
+    
+[[build.env]]
+    name = "BP_LIBERTY_FEATURES"
+    value = "jsonb-2.0 mpconfig-3.0 mpmetrics-4.0 restfulws-3.0 jsonp-2.0 cdi-3.0"     
+    
+[[build.buildpacks]]
+  uri = "docker://gcr.io/paketo-buildpacks/eclipse-openj9"
+  
+[[build.buildpacks]]
+  uri = "docker://gcr.io/paketo-buildpacks/java"
+```
+
+== Using Azure
+Use the link:https://learn.microsoft.com/en-us/cli/azure/acr/pack?view=azure-cli-latest#az_acr_pack_build[az acr pack build] command to build and push a container image using the built-in cloud native buildpack support.   
+For example, the following command builds and pushes the container image using the `mycr` Azure container registry and the full paketo buildacks builder.  The resulting image name is `myapp` and the application source resides in `~/myappsourcedir`.  The application source could also be the url of a git repo.  This example assumes the `mycr` Azure container registry was previously created.  
+
+```
+az acr pack build 
+    --registry mycr 
+    --pull --builder paketobuildpacks/builder:full 
+    --image myapp 
+    ~/myappsourcedir
+```
+
+== Using Google Cloud
+Use the link:https://cloud.google.com/docs/buildpacks/build-application#remote_builds[gcloud builds] command to build and push a container image using the built-in cloud native buildpack support.  
+Follow the link:https://cloud.google.com/docs/buildpacks/build-application#before-you-begin[Before you begin] instructions to setup your environment.  
+
+The basic command syntax is:
+```
+gcloud builds submit --pack image=LOCATION-docker.pkg.dev/PROJECT_ID/REPO_NAME/IMAGE_NAME
+```
+
+In the following example, `us-east1` is the LOCATION, `paketobuildpacks` is the PROJECT_ID, `paketobuildpacktest`` is the REPO_NAME and `javatest` is the IMAGE_NAME.  The command is executed from the application's root directory.  
+
+```
+gcloud builds submit --pack 
+    image=us-east1-docker.pkg.dev/paketobuildpacks/paketobuildpacktest/javatest,builder=paketobuildpacks/builder:full
+
+```
+
+== Other environment variables you can set in the `project.toml` file
+BP_LIBERTY_INSTALL_TYPE::
+Specifies the link:https://github.com/paketo-buildpacks/liberty#install-types[Install type] of Liberty. Open Liberty (value of `ol`) is the default.  Use `wlp` for WebSphere Liberty.  
+
+BP_LIBERTY_PROFILE::
+Specifies which liberty profile to install. Valid profiles for Liberty are documented link:https://github.com/paketo-buildpacks/liberty#profiles[in the buildpacks documentation].  The default profile is `kernel`.  
+
+BP_LIBERTY_FEATURES::
+Specifies a space-separated list of Liberty features to be installed with the Liberty runtime. Supports any valid Liberty feature.
+
+== Taking full advantage of all what the Paketo Buildpack for Liberty has to offer
+Some features of the Paketo Buildpack for Liberty are not easily available to Azure or Google Cloud. Features like link:https://github.com/paketo-buildpacks/liberty/blob/main/docs/installing-ifixes.md[installing iFixes], link:https://github.com/paketo-buildpacks/liberty#using-custom-features[custom features], and installing from a link:https://github.com/paketo-buildpacks/liberty#building-from-a-packaged-server[packaged server] or link:https://github.com/paketo-buildpacks/liberty#building-from-a-liberty-server[server directory] aren't available when you use the built-in support to create the container image.
+
+For these features, you can use the `pack build` CLI to create the container image, tag and push the image to an external container registry. Then, use Azure or Google Cloud to deploy and manage your container by pulling your container image from the container registry.
+
+link:https://cloud.ibm.com/docs/codeengine?topic=codeengine-deploy-app-crimage[Follow these instructions] to deploy applications from the IBM Cloud Container Registry with Code Engine.
+
+== Additional Resources
+* https://cloud.ibm.com/docs/codeengine[Getting started with IBM Cloud Code Engine]
+* https://cloud.ibm.com/docs/codeengine?topic=codeengine-app-local-source-code[Deploying app from local source code using CLI]
+* https://cloud.ibm.com/docs/codeengine?topic=codeengine-build-standalone[Building a container image]
+* https://github.com/paketo-buildpacks/liberty#gcriopaketo-buildpacksliberty[Paketo Buildpack for Liberty]
+* https://paketo.io[Paketo buildpacks]

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -97,7 +97,7 @@ Specifies which Liberty profile to install. Valid profiles for Liberty are docum
 BP_LIBERTY_FEATURES::
 Specifies a space-separated list of Liberty features to be installed with the Liberty runtime. Supports any valid Liberty feature.
 
-== Take full advantage of all what the Paketo Buildpack for Liberty with the pack build CLI
+== Take full advantage of the Paketo Buildpack for Liberty with the pack build CLI
 Some features of the Paketo Buildpack for Liberty are not easily available to Azure or Google Cloud. Features like link:https://github.com/paketo-buildpacks/liberty/blob/main/docs/installing-ifixes.md[installing iFixes], link:https://github.com/paketo-buildpacks/liberty#using-custom-features[custom features], and installing from a link:https://github.com/paketo-buildpacks/liberty#building-from-a-packaged-server[packaged server] or link:https://github.com/paketo-buildpacks/liberty#building-from-a-liberty-server[server directory] aren't available when you use the built-in support to create the container image.  
 
 For these features, you can use the `pack build` CLI to create the container image, tag and push the image to an external container registry. Then, use Azure or Google Cloud to deploy and manage your container by pulling your container image from the container registry.  See link:https://openliberty.io/blog/2022/04/01/cloud-native-liberty-buildpack.html[Introducing the Paketo Liberty Buildpack] for details on using the `pack build` CLI with Liberty.  

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -31,7 +31,7 @@ To build and deploy container images or create a link:https://buildpacks.io/docs
 * https://www.docker.com/[Docker] or https://podman.io[Podman]. This post focuses on Docker. For information about using Podman with Paketo, refer to the buildpacks.io documentation for https://buildpacks.io/docs/app-developer-guide/building-on-podman/[Building on Podman]. 
 * An externally accessible container registry that can host your images.
 
-The Paketo Buildpack for Liberty is included in the composite Paketo Buildpack for Java that also includes `tomcat` and `tomee` application servers. Tomcat is the default application server and to use Open Liberty requires a little extra configuration.  The Paketo Buildpack for Java includes the Bellsofit Liberica as the default JVM provider.  To use other JVM providers requires extra configuration.  
+The Paketo Buildpack for Liberty is included in the composite Paketo Buildpack for Java that also includes `tomcat` and `tomee` application servers. Tomcat is the default application server and to use Open Liberty requires a little extra configuration.  The Paketo Buildpack for Java includes Bellsoft Liberica as the default JVM provider.  To use other JVM providers requires extra configuration.  
 
 You can set the application server that the Paketo Buildpack for Java uses by specifying the `BP_JAVA_APP_SERVER` environment variable and select an alternate JVM provider using a link:https://buildpacks.io/docs/app-developer-guide/using-project-descriptor/[project descriptor]. 
 

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -41,7 +41,7 @@ Create the project descriptior file, `project.toml`, in the application's root s
 
 To use the alternate and preferred Eclipse OpenJ9 JVM,  change the order that the buildpacks run in the project descriptor.  To minimize the size of the application container image, the buildpack installs the Liberty kernel profile by default.  You can override the profile using the `BP_LIBERTY_PROFILE` environment variable or use the `BP_LIBERTY_FEATURES` environment variable to install the Liberty features your application requires.  
 
-For example, your project descriptor should contain the following content to use the liberty applicaiton server, install eclipse openj9, install the kernel profile and install a set of liberty features:
+For example, your project descriptor might contain the following content to use the Liberty runtime and install Eclipse OpenJ9, the Liberty kernel profile, and a set of Liberty features:
 ```
 [[build.env]]
     name = "BP_JAVA_APP_SERVER"

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -92,7 +92,7 @@ BP_LIBERTY_INSTALL_TYPE::
 Specifies the link:https://github.com/paketo-buildpacks/liberty#install-types[Install type] of Liberty. Open Liberty (value of `ol`) is the default.  Use `wlp` for WebSphere Liberty.  
 
 BP_LIBERTY_PROFILE::
-Specifies which liberty profile to install. Valid profiles for Liberty are documented link:https://github.com/paketo-buildpacks/liberty#profiles[in the buildpacks documentation].  The default profile is `kernel`.  
+Specifies which Liberty profile to install. Valid profiles for Liberty are documented link:https://github.com/paketo-buildpacks/liberty#profiles[in the buildpacks documentation]. The default profile is `kernel`.  
 
 BP_LIBERTY_FEATURES::
 Specifies a space-separated list of Liberty features to be installed with the Liberty runtime. Supports any valid Liberty feature.

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -23,7 +23,6 @@ This post provides instructions on how to use the Paketo Buildpack for Liberty w
 == What do you need?
 * An https://azure.microsoft.com/en-us/free/[Azure] or https://cloud.google.com/free/[Google Cloud] Account
 * The link:https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Azure cli] or the link:https://cloud.google.com/sdk/docs/install[gcloud cli]
-* The link:https://cloud.google.com/sdk/docs/install[gcloud cli]
 * Your application source
 
 To build and deploy container images or create a link:https://buildpacks.io/docs/concepts/components/builder/[custom builder], you'll also need:

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -98,9 +98,9 @@ BP_LIBERTY_FEATURES::
 Specifies a space-separated list of Liberty features to be installed with the Liberty runtime. Supports any valid Liberty feature.
 
 == Take full advantage of all what the Paketo Buildpack for Liberty with the pack build CLI
-Some features of the Paketo Buildpack for Liberty are not easily available to Azure or Google Cloud. Features like link:https://github.com/paketo-buildpacks/liberty/blob/main/docs/installing-ifixes.md[installing iFixes], link:https://github.com/paketo-buildpacks/liberty#using-custom-features[custom features], and installing from a link:https://github.com/paketo-buildpacks/liberty#building-from-a-packaged-server[packaged server] or link:https://github.com/paketo-buildpacks/liberty#building-from-a-liberty-server[server directory] aren't available when you use the built-in support to create the container image.
+Some features of the Paketo Buildpack for Liberty are not easily available to Azure or Google Cloud. Features like link:https://github.com/paketo-buildpacks/liberty/blob/main/docs/installing-ifixes.md[installing iFixes], link:https://github.com/paketo-buildpacks/liberty#using-custom-features[custom features], and installing from a link:https://github.com/paketo-buildpacks/liberty#building-from-a-packaged-server[packaged server] or link:https://github.com/paketo-buildpacks/liberty#building-from-a-liberty-server[server directory] aren't available when you use the built-in support to create the container image.  
 
-For these features, you can use the `pack build` CLI to create the container image, tag and push the image to an external container registry. Then, use Azure or Google Cloud to deploy and manage your container by pulling your container image from the container registry.
+For these features, you can use the `pack build` CLI to create the container image, tag and push the image to an external container registry. Then, use Azure or Google Cloud to deploy and manage your container by pulling your container image from the container registry.  See link:https://openliberty.io/blog/2022/04/01/cloud-native-liberty-buildpack.html[Introducing the Paketo Liberty Buildpack] for details on using the `pack build` CLI with Liberty.  
 
 == Additional Resources
 * https://learn.microsoft.com/en-us/azure/container-registry/container-registry-tasks-pack-build[Using cloud native buildpacks in Azure]

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -58,7 +58,7 @@ For example, your project descriptor might contain the following content to use 
   uri = "docker://gcr.io/paketo-buildpacks/java"
 ```
 
-== Using Azure
+== Build and push a container image with Azure
 Use the link:https://learn.microsoft.com/en-us/cli/azure/acr/pack?view=azure-cli-latest#az_acr_pack_build[az acr pack build] command to build and push a container image using the built-in cloud native buildpack support.   
 For example, the following command builds and pushes the container image using the `mycr` Azure container registry and the full Paketo Buildpacks builder.  The resulting image name is `myapp` and the application source resides in `~/myappsourcedir`.  The application source can also be specified as the URL of a Git repo.  This example assumes the `mycr` Azure container registry was previously created.  
 

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -79,7 +79,7 @@ The basic command syntax is:
 gcloud builds submit --pack image=LOCATION-docker.pkg.dev/PROJECT_ID/REPO_NAME/IMAGE_NAME
 ```
 
-In the following example, `us-east1` is the LOCATION, `paketobuildpacks` is the PROJECT_ID, `paketobuildpacktest`` is the REPO_NAME and `javatest` is the IMAGE_NAME.  The command is executed from the application's root directory.  
+In the following example, `us-east1` is the LOCATION, `paketobuildpacks` is the PROJECT_ID, `paketobuildpacktest` is the REPO_NAME and `javatest` is the IMAGE_NAME.  The command is executed from the application's root directory.  
 
 ```
 gcloud builds submit --pack 

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -18,7 +18,7 @@ Kevin Ortega <https://github.com/kevin-ortega>
 Azure and Google Cloud have built-in support for link:https://buildpacks.io[cloud native buildpacks].  
 You can use link:https://learn.microsoft.com/en-us/azure/container-registry/container-registry-tasks-pack-build[Azure] or link:https://cloud.google.com/docs/buildpacks/build-application[Google Cloud] to easily deploy Java applications by using the link:https://openliberty.io/blog/2022/04/01/cloud-native-liberty-buildpack.html[Paketo Buildpack for Liberty] with your source code or container images.
 
-This post provides instructions on how to use the Paketo Buildpack for Liberty with Azure and Google Cloud. To learn more about using Azure and Google Cloud see their respective documentation.  
+This post provides instructions on how to use the Paketo Buildpack for Liberty with Azure and Google Cloud. To learn more about using Azure and Google Cloud, see their respective documentation.  
 
 == What do you need?
 * An https://azure.microsoft.com/en-us/free/[Azure] or https://cloud.google.com/free/[Google Cloud] Account

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -37,7 +37,9 @@ You can set the application server that the Paketo Buildpack for Java uses by sp
 
 == Let's get started
 
-Create the project descriptior file, `project.toml`, in the application's root source directory. At a minimum, `project.toml` should contain `BP_JAVA_APP_SERVER=liberty` but can contain other environment variables consumed by buildpacks.  To use the alternate and preferred JVM, eclipse openj9, we change the order that the buildpacks run in the project descriptor.   To minimize the size of the application container image, the buildpack by default installs the kernel profile.  You can override the profile using the `BP_LIBERTY_PROFILE` environment variable or use the `BP_LIBERTY_FEATURES` environment variable to install the features required by the application.  
+Create the project descriptior file, `project.toml`, in the application's root source directory. At a minimum, `project.toml` must  specify the `BP_JAVA_APP_SERVER=liberty` environment variable but can contain other environment variables that are consumed by buildpacks.  
+
+To use the alternate and preferred Eclipse OpenJ9 JVM,  change the order that the buildpacks run in the project descriptor.  To minimize the size of the application container image, the buildpack installs the Liberty kernel profile by default.  You can override the profile using the `BP_LIBERTY_PROFILE` environment variable or use the `BP_LIBERTY_FEATURES` environment variable to install the Liberty features your application requires.  
 
 For example, your project descriptor should contain the following content to use the liberty applicaiton server, install eclipse openj9, install the kernel profile and install a set of liberty features:
 ```

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -87,7 +87,7 @@ gcloud builds submit --pack
 
 ```
 
-== Other environment variables you can set in the `project.toml` file
+== Liberty environment variables you can set in the `project.toml` file
 BP_LIBERTY_INSTALL_TYPE::
 Specifies the link:https://github.com/paketo-buildpacks/liberty#install-types[Install type] of Liberty. Open Liberty (value of `ol`) is the default.  Use `wlp` for WebSphere Liberty.  
 

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -101,11 +101,8 @@ Some features of the Paketo Buildpack for Liberty are not easily available to Az
 
 For these features, you can use the `pack build` CLI to create the container image, tag and push the image to an external container registry. Then, use Azure or Google Cloud to deploy and manage your container by pulling your container image from the container registry.
 
-link:https://cloud.ibm.com/docs/codeengine?topic=codeengine-deploy-app-crimage[Follow these instructions] to deploy applications from the IBM Cloud Container Registry with Code Engine.
-
 == Additional Resources
-* https://cloud.ibm.com/docs/codeengine[Getting started with IBM Cloud Code Engine]
-* https://cloud.ibm.com/docs/codeengine?topic=codeengine-app-local-source-code[Deploying app from local source code using CLI]
-* https://cloud.ibm.com/docs/codeengine?topic=codeengine-build-standalone[Building a container image]
+* https://learn.microsoft.com/en-us/azure/container-registry/container-registry-tasks-pack-build[Using cloud native buildpacks in Azure]
+* https://cloud.google.com/docs/buildpacks/build-application[Building an application with buildpacks on Google Cloud]
 * https://github.com/paketo-buildpacks/liberty#gcriopaketo-buildpacksliberty[Paketo Buildpack for Liberty]
 * https://paketo.io[Paketo buildpacks]

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -70,7 +70,7 @@ az acr pack build
     ~/myappsourcedir
 ```
 
-== Using Google Cloud
+== Build and push a container image with Google Cloud
 Use the link:https://cloud.google.com/docs/buildpacks/build-application#remote_builds[gcloud builds] command to build and push a container image using the built-in cloud native buildpack support.  
 Follow the link:https://cloud.google.com/docs/buildpacks/build-application#before-you-begin[Before you begin] instructions to setup your environment.  
 

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -97,7 +97,7 @@ Specifies which liberty profile to install. Valid profiles for Liberty are docum
 BP_LIBERTY_FEATURES::
 Specifies a space-separated list of Liberty features to be installed with the Liberty runtime. Supports any valid Liberty feature.
 
-== Taking full advantage of all what the Paketo Buildpack for Liberty has to offer
+== Take full advantage of all what the Paketo Buildpack for Liberty with the pack build CLI
 Some features of the Paketo Buildpack for Liberty are not easily available to Azure or Google Cloud. Features like link:https://github.com/paketo-buildpacks/liberty/blob/main/docs/installing-ifixes.md[installing iFixes], link:https://github.com/paketo-buildpacks/liberty#using-custom-features[custom features], and installing from a link:https://github.com/paketo-buildpacks/liberty#building-from-a-packaged-server[packaged server] or link:https://github.com/paketo-buildpacks/liberty#building-from-a-liberty-server[server directory] aren't available when you use the built-in support to create the container image.
 
 For these features, you can use the `pack build` CLI to create the container image, tag and push the image to an external container registry. Then, use Azure or Google Cloud to deploy and manage your container by pulling your container image from the container registry.

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -60,7 +60,7 @@ For example, your project descriptor might contain the following content to use 
 
 == Using Azure
 Use the link:https://learn.microsoft.com/en-us/cli/azure/acr/pack?view=azure-cli-latest#az_acr_pack_build[az acr pack build] command to build and push a container image using the built-in cloud native buildpack support.   
-For example, the following command builds and pushes the container image using the `mycr` Azure container registry and the full paketo buildacks builder.  The resulting image name is `myapp` and the application source resides in `~/myappsourcedir`.  The application source could also be the url of a git repo.  This example assumes the `mycr` Azure container registry was previously created.  
+For example, the following command builds and pushes the container image using the `mycr` Azure container registry and the full Paketo Buildpacks builder.  The resulting image name is `myapp` and the application source resides in `~/myappsourcedir`.  The application source can also be specified as the URL of a Git repo.  This example assumes the `mycr` Azure container registry was previously created.  
 
 ```
 az acr pack build 

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -74,7 +74,7 @@ az acr pack build
 Use the link:https://cloud.google.com/docs/buildpacks/build-application#remote_builds[gcloud builds] command to build and push a container image using the built-in cloud native buildpack support.  
 Follow the link:https://cloud.google.com/docs/buildpacks/build-application#before-you-begin[Before you begin] instructions to setup your environment.  
 
-The basic command syntax is:
+The command uses the following basic syntax:
 ```
 gcloud builds submit --pack image=LOCATION-docker.pkg.dev/PROJECT_ID/REPO_NAME/IMAGE_NAME
 ```

--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -22,7 +22,7 @@ This post provides instructions on how to use the Paketo Buildpack for Liberty w
 
 == What do you need?
 * An https://azure.microsoft.com/en-us/free/[Azure] or https://cloud.google.com/free/[Google Cloud] Account
-* The link:https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Azure cli] or
+* The link:https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Azure cli] or the link:https://cloud.google.com/sdk/docs/install[gcloud cli]
 * The link:https://cloud.google.com/sdk/docs/install[gcloud cli]
 * Your application source
 


### PR DESCRIPTION
@GraceJansen 

Link to [blog](https://blogs-draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/blog/2023/02/17/using-liberty-buildpack-on-azure-and-google-cloud.html) on draft site.  

Open issue, #2862 

![image](https://user-images.githubusercontent.com/29545669/217887311-7ee82163-e27e-4bb1-bcb2-27decffb7aa7.png)
![image](https://user-images.githubusercontent.com/29545669/217887422-1278f235-72c2-4fe6-b429-127defc0599e.png)
![image](https://user-images.githubusercontent.com/29545669/217887495-3cabf0ea-59d5-44d7-aed6-d694658eca41.png)
