### PR TITLE
Japanese translation of 23.0.0.2 release blog

### DIFF
--- a/posts/2023-03-07-23.0.0.2.adoc
+++ b/posts/2023-03-07-23.0.0.2.adoc
@@ -10,6 +10,9 @@ seo-description: Open Liberty 23.0.0.2 introduces a new capability to test datab
 blog_description: Open Liberty 23.0.0.2 introduces a new capability to test database connections with the Admin Center Server Config tool. The server stop command adds the the --timeout option to specify the maximum amount of time to wait for the server to stop. This release also provides many significant bug fixes, including one that addresses a CVE in Jakarta RESTful Web Services 3.0 feature.
 open-graph-image: https://openliberty.io/img/blog/ac_db_test_container_auth.png
 open-graph-image-alt: Open Liberty Admin Center connection test panel
+blog-available-in-languages:
+- lang: ja
+  path: /ja/blog/2023/03/26/23.0.0.2.html
 ---
 = Test database connections and set server stop time out in Open Liberty 23.0.0.2
 Michal Broz <https://github.com/mbroz2>

--- a/posts/ja/Japanese_2023-03-26-23.0.0.2.adoc
+++ b/posts/ja/Japanese_2023-03-26-23.0.0.2.adoc
@@ -1,0 +1,336 @@
+---
+layout: post
+title: "Open Liberty 23.0.0.2でのデータベース接続のテストとサーバー停止タイムアウトの設定"
+# Do NOT change the categories section
+categories: blog
+author_picture: https://avatars3.githubusercontent.com/mbroz2
+author_github: https://github.com/mbroz2
+seo-title: Open Liberty 23.0.0.2でのデータベース接続のテストとサーバー停止タイムアウトの設定 - OpenLiberty.io
+seo-description: Open Liberty 23.0.0.2 では、Admin Center Server Config ツールでデータベース接続をテストする新しいフィーチャーが導入されました。server stopコマンドに、サーバーが停止するまでの最大待機時間を指定するための-timeoutオプションが追加されました。このリリースでは、Jakarta RESTful Web Services 3.0フィーチャーのCVEに対処したものを含む、多くの重要なバグ修正も提供します。
+blog_description: Open Liberty 23.0.0.2 では、Admin Center Server Config ツールでデータベース接続をテストする新しいフィーチャーが導入されました。server stopコマンドに、サーバーが停止するまでの最大待機時間を指定するための-timeoutオプションが追加されました。このリリースでは、Jakarta RESTful Web Services 3.0フィーチャーのCVEに対処したものを含む、多くの重要なバグ修正も提供します。
+open-graph-image: https://openliberty.io/img/blog/ac_db_test_container_auth.png
+open-graph-image-alt: Liberty Admin Centerの接続テストパネルを開く
+blog-available-in-languages:
+- lang: en
+  path: /blog/2023/03/07/23.0.0.2.html
+---
+= Open Liberty 23.0.0.2でのデータベース接続のテストとサーバー停止タイムアウトの設定
+Michal Broz <https://github.com/mbroz2>
+:imagesdir: /
+:url-prefix:
+:url-about: /
+//Blank line here is necessary before starting the body of the post.
+
+Open Liberty 23.0.0.2 では、Admin Center Server Config ツールでデータベース接続をテストする新しいフィーチャーが導入されました。server stopコマンドに、サーバーが停止するまでの最大待機時間を指定するための-timeoutオプションが追加されました。このリリースでは、Jakarta RESTful Web Services 3.0フィーチャーのCVEに対処したものを含む、多くの重要なバグ修正も提供します。
+
+
+In link:{url-about}[Open Liberty] 23.0.0.2:
+
+* <<db_test, Admin Centerを使ったデータベース接続のテスト>>
+* <<timeout, サーバーが停止するまでの待ち時間を指定>>
+* <<CVEs, セキュリティ脆弱性(CVE)修正プログラム>>
+* <<bugs, 主なバグ修正>>
+
+
+Along with the new features and functions added to the runtime, we’ve also made 
+ランタイムに追加された新フィーチャーと一緒に<<guides, ガイドの更新>>を作成しました。
+
+
+修正された主なバグリストはlink:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A23002+label%3A%22release+bug%22[23.0.0.2]からご確認いただけます。
+
+link:{url-prefix}/blog/?search=release&search!=beta[Open Liberty GAのリリースブログの記事]もご確認ください
+
+
+[#run]
+
+
+== 23.0.0.2を使ってアプリを実行する
+
+link:{url-prefix}/guides/maven-intro.html[Maven]を使う時には下記の設定をお使いください。
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.openliberty</groupId>
+    <artifactId>openliberty-runtime</artifactId>
+    <version>23.0.0.2</version>
+    <type>zip</type>
+</dependency>
+----
+
+link:{url-prefix}/guides/gradle-intro.html[Gradle]の場合はこちらです。
+
+[source,gradle]
+----
+dependencies {
+    libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '[23.0.0.2,)'
+}
+----
+
+Dockerの場合はこちらです。
+
+[source]
+----
+FROM open-liberty
+----
+
+またはlink:{url-prefix}/downloads/[ダウンロード・ページ]をご参照ください。
+
+[link=https://stackoverflow.com/tags/open-liberty]
+image::img/blog/blog_btn_stack_ja.svg[Stack Overflowで質問する, align="center"]
+
+
+// // // // DO NOT MODIFY THIS COMMENT BLOCK <GHA-BLOG-TOPIC> // // // // 
+// Blog issue: https://github.com/OpenLiberty/open-liberty/issues/24124
+// Contact/Reviewer: aknguyen7,ReeceNana
+// // // // // // // // 
+[#db_test]
+== Admin Centerを使用してデータベース接続をテストする   
+
+データベース接続をテストする簡単な方法をお探しですか？このリリースでは、Liberty Admin Centerのフィーチャーを使用して、接続を検証できるようになりました。接続テストは、アプリケーションと同じコードパスを実行するため、サーバー構成に確信を持つことができます。Admin Centerの接続検証フィーチャーはlink:{url-prefix}/blog/2019/09/13/testing-database-connections-REST-APIs.html[REST APIsによるOpen Libertyアプリのデータベース接続テスト]で紹介した同じREST APIsで有効です。
+
+
+データベース接続テストを有効にするには、サーバー構成に以下の最低限必要なフィーチャーのセットを用意する必要があります。
+
+[source, xml]
+----
+    <feature>adminCenter-1.0</feature>
+    <feature>restConnector-2.0</feature>
+    <feature>mpOpenApi-3.0</feature>
+----
+
+この例では `mpOpenApi-3.0` フィーチャーを使用していますが、他のフィーチャーと互換性のある任意の MicroProfile OpenAPI バージョンを使用することができます。
+
+
+例として、まずサーバーリソース `DefaultDataSource` をテストします。このリソースは、認証エイリアスを使用したコンテナ認証を使用してDerbyデータベースに接続するように構成されています。
+
+以下のサンプル `server.xml` ファイルは、Admin Center のテスト接続フィーチャーを設定し、Derby データベースへの接続を設定するフィーチャーを有効にします。
+
+[source, xml]
+----
+<server description="new server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>adminCenter-1.0</feature>
+        <feature>restConnector-2.0</feature>
+        <feature>jdbc-4.3</feature>
+        <feature>mpOpenApi-3.0</feature>
+    </featureManager>
+
+    <!--リモートクライアントからこのサーバーにアクセスするには、次の要素にhost属性を追加してください　例：host="*" -->
+    <httpEndpoint id="defaultHttpEndpoint" httpPort="9080" httpsPort="9443"/>
+
+    <library id="derby">
+      <file name="${server.config.dir}/derby/derby.jar"/>
+    </library>
+
+    <dataSource id="DefaultDataSource">
+      <jdbcDriver libraryRef="derby"/>
+      <!-- インメモリDerby Embeddedデータベースを参照するプロパティ例 -->
+      <properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create"/>
+    </dataSource>
+
+    <authData id="myAuth" user="dbuser" password="dbpass"/>
+
+    <!-- デフォルトのSSL設定により、Javaランタイムのデフォルト証明書を信頼することが可能 --> 
+    <ssl id="defaultSSLConfig" trustDefaultCerts="true"/>
+
+    <remoteFileAccess>
+       <writeDir>${server.config.dir}</writeDir>
+    </remoteFileAccess>
+
+    <basicRegistry id="basic">
+       <user name="admin" password="adminpwd"/>
+    </basicRegistry>
+
+    <!-- 管理者に「admin」を割り当てる -->
+    <administrator-role>
+        <user>admin</user>
+    </administrator-role>
+
+</server>
+----
+
+この `server.xml` の例では、Derby JAR をサーバー設定に追加するか、独自のデータベース設定を使用する必要があります。
+
+
+1. サンプルの `server.xml` ファイルを参考に Liberty サーバを設定し、サーバを起動します。サーバーが起動したら、ログを確認して、Admin Center に移動するための URL を見つけることができます。前の例では、`https://localhost:9443/adminCenter/` URL を使用して Admin Center に移動することができます。
+
+
+2. Admin Center UI で、**Server Config** ツールを選択します。
+
++
+[.img_border_light]
+image::img/blog/ac_db_test_server_config.png[Server Config Tool,width=20%,align="center"]
+
+3. 編集する **server.xml** を選択します。
+
++
+[.img_border_light]
+image::img/blog/ac_db_test_serverxml.png[server.xml,width=50%,align="center"]
+
+4. Design > Server** メニューで、テストしたいリソースに移動し、**Test** ボタンをクリックします。
+
++
+[.img_border_light]
+image::img/blog/ac_db_test_resource.png[リソースを選択,width=50%,align="center"]
+
+5. アプリケーションが使用する認証の種類を選択します。
+
++
+* コンテナ認証を使用するアプリケーションでは、**コンテナ認証**タブを選択し、デフォルト認証を使用するか、認証エイリアスを指定するか、ログインモジュール構成を選択するかを選択します。
+
++
+この例では、`dataSource`要素にデフォルトの認証を指定したり、ログインモジュールを設定するような構成にはなっていません。したがって、ドロップダウン・フィールドを使用して認証エイリアスを指定する必要があります。
+
++
+[.img_border_light]
+image::img/blog/ac_db_test_container_auth.png[コンテナ認証,width=50%,align="center"]
+
+
+* アプリケーション認証を使用するアプリケーションでは、**アプリケーション認証**タブを選択し、データベースリソースの有効なユーザー名とパスワードを入力します。
+
++
+[.img_border_light]
+image::img/blog/ac_db_test_app_auth.png[アプリケーション認証,width=50%,align="center"]
+
+* アプリケーションがリソース参照を使用しない場合、`server.xml` のlink:{url-prefix}/docs/latest/reference/config/connectionManager.html[`connectionManager` element]を選択し、**No resource reference**タブを選択し、データベースリソースの有効なユーザー名とパスワードを入力します。
+
+
++
+[.img_border_light]
+image::img/blog/ac_db_test_no_resource_ref.png[リソース参照なし,width=50%,align="center"]
+
+6. **Connection Test**ボタンをクリックすると、テストが実行され、結果が表示されます。 次の例は、接続テストに成功した例です。
+
+
+[.img_border_light]
+image::img/blog/ac_db_test_successful_test.png[接続テストに成功した例,width=50%,align="center"]
+
+さらにlink:{url-prefix}/docs/latest/reference/feature/jdbc-4.3.html[Java Database Connectivity]に加えて、link:{url-prefix}/docs/latest/reference/feature/connectors-2.0.html[Jakartaコネクター], link:{url-prefix}/docs/latest/reference/feature/messaging-3.0.html[Jakartaメッセージング]とlink:{url-prefix}/docs/latest/reference/feature/cloudant-1.0.html[Cloudant Integration]リソースへのテスト接続も可能です。 
+
+GUIによるLibertyの管理については、link:{url-prefix}/docs/latest/admin-center.html[Admin CenterでOpen Libertyを管理する]ドキュメントをご参照ください。
+
+// DO NOT MODIFY THIS LINE. </GHA-BLOG-TOPIC> 
+
+// // // // DO NOT MODIFY THIS COMMENT BLOCK <GHA-BLOG-TOPIC> // // // // 
+// Blog issue: https://github.com/OpenLiberty/open-liberty/issues/23282
+// Contact/Reviewer: jimblye,ReeceNana
+// // // // // // // // 
+[#timeout]
+== サーバーが停止するまでの待ち時間を指定する
+
+Open Liberty 23.0.0.2 では、`server stop` コマンドに `--timeout` コマンドラインオプションが追加されました。 このオプションを使用すると、`server stop` コマンドがサーバーが停止したことを確認するために待機する最大時間を指定することができます。 
+
+今回のアップデート以前は、デフォルトの最大待機時間である30秒を調整することができませんでした。
+
+タイムアウト値は分単位（`m`）、秒単位（`s`）、またはその両方を組み合わせて指定することができます。 単位が指定されない場合、デフォルトである秒が使用されます。 分と秒は組み合わせることができ、例えば `2m30s` は2分30秒を意味します。 
+   
+[source, xml]
+----
+   ./server stop                   // 30 seconds
+   ./server stop --timeout=45      // 45 seconds
+   ./server stop --timeout=45s     // 45 seconds
+   ./server stop --timeout=3m20s   // 3 minutes, 20 seconds
+----
+
+タイムアウト値のデフォルトは30秒です。サーバーの停止に常に30秒以上かかる場合は、-timeoutオプションを使用してタイムアウト値を増やすことを検討してください。
+
+詳細はlink:{url-prefix}/docs/latest/reference/command/server-stop.html[server stop command]ドキュメントをご参照ください。
+   
+// DO NOT MODIFY THIS LINE. </GHA-BLOG-TOPIC> 
+
+
+[#CVEs]
+== 本リリースにおけるセキュリティ脆弱性（CVE）修正
+[cols="5*"]
+|===
+|CVE |CVSSスコア |脆弱性評価 |影響を受けるバージョン |ノート
+
+|http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45787[CVE-2022-45787]
+|5.5
+|Information disclosure
+|21.0.0.12 - 23.0.0.1
+|link:{url-prefix}/docs/latest/reference/feature/restfulWS-3.0.html[restfulWS-3.0] フィーチャーに影響あり
+|===
+
+過去のセキュリティ脆弱性の修正のリストについては、link:{url-prefix}/docs/latest/security-vulnerabilities.html[Security vulnerability (CVE) list]をご参照ください。
+
+
+[#bugs]
+== 主なバグ修正
+
+以下のセクションでは、このリリースで修正したバグの一部について説明します。興味がある場合はlink:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A23002+label%3A%22release+bug%22[full list of bugs fixed in 23.0.0.2]をご参照ください。
+
+* link:https://github.com/OpenLiberty/open-liberty/issues/24371[サーブレット・フィーチャーの競合により、サーバーの起動に失敗する]
++
+link:link:{url-prefix}/docs/latest/reference/command/featureUtility-installFeature.html[`featureUtility installFeature`]コマンドでEE7またはEE8の機能セットを個別にインストールする場合、以下の例のようにサーブレット・フィーチャーでの競合によりサーバー起動できない場合があります。
+
++
+[source]
+----
+com.ibm.ws.kernel.feature.internal.FeatureManager            E CWWKF0033E: The singleton features servlet-3.1 and servlet-3.0 cannot be loaded at the same time.  The configured features servlet-3.1 and apiDiscovery-1.0 include one or more features that cause the conflict. Your configuration is not supported; update server.xml to remove incompatible features.
+com.ibm.ws.logging.internal.impl.IncidentImpl                I FFDC1015I: An FFDC Incident has been created: "java.lang.IllegalArgumentException: Unable to load conflicting versions of features "com.ibm.websphere.appserver.servlet-3.1" and "com.ibm.websphere.appserver.servlet-3.0".  The feature dependency chains that led to the conflict are: com.ibm.websphere.appserver.servlet-3.1 and com.ibm.websphere.appserver.apiDiscovery-1.0 -> com.ibm.websphere.appserver.restHandler-1.0 -> io.openliberty.restHandler.internal-1.0 -> io.openliberty.webBundleSecurity.internal-1.0 -> io.openliberty.servlet.internal-3.0 -> com.ibm.websphere.appserver.servlet-3.0
+----
++
+代わりにlink:{url-prefix}/docs/latest/reference/command/featureUtility-installServerFeatures.html[`featureUtility installServerFeatures`]コマンドを使用するとこの問題は発生しません。また、Jakarta EE 8の機能を使用する場合は、`mpJwt-1.2`フィーチャーをインストールすることで回避することができます。
+
++
+この問題は解決され、`featureUtility installFeature`コマンドは、すべての機能を`server.xml`に含めることができるようにインストールし、サーバーを正しく起動することができるようになりました。
+
+* link:https://github.com/OpenLiberty/open-liberty/issues/24293[アプリケーション停止時にManaged Executor ServicesからScheduled Futuresがリソースをリークする]
++
+ManagedScheduledExecutorServiceImpl`の`futures`キューは、スケジュールされたフューチャーの参照を保持し、それが完了した後でも保持します。
++
+キューは、新しいタスクがスケジュールされると、プライベートな `purgeFutures()` メソッドによって定期的にクリーニングされますが、それ以外は積極的に削除されることはありませんし、アプリケーションがシャットダウンしたときにも呼ばれません。purgeFutures()`はプライベートなので、アプリケーションが自分自身で呼び出すことはできません。
++
+この問題は解決され、アプリケーションの停止時にリソースが自動的に解放されるようになりました。
+
+* link:https://github.com/OpenLiberty/open-liberty/issues/24157[HTTPヘッダー名の検証]
++
+バグにより、HTTPリクエストで無効な文字がないかチェックされていませんでした。
++
+この問題は解決され、無効な文字を含むHTTPリクエストは、HTTPレスポンスに`400`レスポンスコードが含まれるようになりました。
+
+* link:https://github.com/OpenLiberty/open-liberty/issues/24077[DoNotAllowDuplicateSetCookies httpチャネル設定オプションが動作しない]
++
+HTTPチャネルの設定プロパティ `DoNotAllowDuplicateSetCookies=true` を設定しても、HTTPレスポンスで重複した `Set-Cookie` クッキーを許可します。
++
+この問題は解決され、DoNotAllowDuplicateSetCookies=true`が設定されている場合、レスポンスヘッダーには重複した `Set-Cookie` のクッキーが含まれないようになりました。
+
+* link:https://github.com/OpenLiberty/open-liberty/issues/24056[batch-1.0、2.0を設定してもbatch-2.1の機能コンテンツは有効です]
++
+ベータ版の `batch-2.1` 機能の一部として追加されたコンテンツは、ユーザーがlink:{url-prefix}/docs/latest/reference/feature/batch-1.0.html[`batch-1.0`]もしくは link:{url-prefix}/docs/latest/reference/feature/batch-2.0.html[`batch-2.0`]としてサーバーを設定しても読み込まれて有効になります。これは意図的ではなく、ユーザーの環境に応じてコンフリクトが発生する可能性があります。
++
+この問題は解決され、新しい `batch-2.1` 固有のコンテンツは `batch-1.0` や `batch-2.0` の機能で公開されなくなりました。
+
+* link:https://github.com/OpenLiberty/open-liberty/issues/24001[CWWKS1738Eメッセージで使用されるコンフィギュレーション属性名を修正]
++
+link:{url-prefix}/docs/latest/reference/feature/socialLogin-1.0.html[ソーシャルメディア・ログイン・フィーチャー]経由でOIDC RPを使用する場合、OPから返されたIDトークンに期待したユーザー名の項目がない場合に、誤ったコンフィギュレーション属性名を含むエラーメッセージが出てしまう可能性があります。以下は、そのようなエラーメッセージの例です。
++
+[source]
+----
+.ws.security.openidconnect.clients.common.AttributeToSubject E CWWKS1738E: The OpenID Connect client [client01] failed to authenticate the JSON Web Token because the claim [someBadName] specified by the [userIdentifier] configuration attribute was not included in the token.
+----
++
+エラーメッセージは `userIdentifier` というコンフィグレーション属性に言及しています。しかし、`socialLogin-1.0`の機能では、同等のコンフィグレーション属性は実際には`userNameAttribute`と呼ばれます。
++
+この問題は、正しい属性名を参照するようにNLSメッセージを更新することで解決されました。
+
+
+[#guides]
+== 前回のリリース以降の新しいガイドと更新されたガイド
+Open Libertyの特徴や機能が増え続ける中、できるだけ簡単に導入できるように、それらのトピックに関するlink:https://openliberty.io/guides/?search=new&key=tag[openliberty.ioへの新しいガイド]を追加しています。既存のガイドも、報告されたバグや問題に対処し、内容を最新に保ち、トピックの内容を拡張するために更新されます。
+
+
+* link:{url-prefix}/guides/grpc-intro.html[gRPCを使ったクライアントとサーバーのサービス間のメッセージストリーミング] 
+** この度発行されたガイドのクラウドホスト版が公開されました。
+
+[.img_border_light]
+image::img/blog/grpc_guide.png[アプリケーション認証,width=50%,align="center"]
+
+
+== 今すぐOpen Liberty 23.0.0.2を入手する
+
+<<run,Maven, Gradle, Docker, ダウンロード可能なアーカイブ>>から利用可能です。


### PR DESCRIPTION
Issue: https://github.com/OpenLiberty/blogs/issues/2991
- Translation contributed by [Kaori](https://github.com/kaori-asa) 
- I held off adding the translator section in this blog. I would like to do the way @kinueng did nicely [here](https://ibm-cloud.slack.com/archives/C4U7TQUSY/p1676984205210509).  It will be great if the[ translation process](https://github.com/OpenLiberty/blogs/wiki/i18n) will be updated so I can learn and refer back every month. 
- I did not request Kaori to provide the explanation on why some of the link remained as-is. It could be the original articles or specs that should not be translated, or Proper Nouns or customary to keep it in English.  Please find the discussion[ in this slack thread. ](https://ibm-cloud.slack.com/archives/C0146DEBAKS/p1678376092171129)
- I put the blog publish date tentatively 3/26. Please change it to suite the blog team's schedule. 

Thanks! 


