### PR TITLE
Correct issuerIdentifier OIDC client attribute references in Sep 2022 post

### DIFF
--- a/posts/2022-09-27-22.0.0.10.adoc
+++ b/posts/2022-09-27-22.0.0.10.adoc
@@ -78,7 +78,7 @@ image::img/blog/blog_btn_stack.svg[Ask a question on Stack Overflow, align="cent
 
 Starting in 22.0.0.10, the link:{url-prefix}/docs/latest/reference/feature/openidConnectClient-1.0.html[OpenID Connect Client 1.0] feature supports using the issuer claim from the JWT or JWS access token for selecting which `openidConnectClient` configuration to use for a JWT inbound propagation request.  Prior to this release, complicated authentication filters were required if more than one issuer was used for the same resource. Instead, the OpenID Connect Client 1.0 feature can now be configured with simpler `openidConnectClient` elements for each required issuer.
 
-A Liberty OpenID Connect Relying Party will automatically use the issuer claim from a JWT or JWS access token to select the `openidConnectClient` configuration with a matching `issuer` attribute. 
+A Liberty OpenID Connect Relying Party will automatically use the issuer claim from a JWT or JWS access token to select the `openidConnectClient` configuration with a matching `issuerIdentifier` attribute. 
 
 The following `server.xml` file example shows two Open ID connect client configurations, with an link:{url-prefix}/docs/latest/authentication-filters.html[authentication filter] configured to route requests to the `RP2` configuration. If a request with an issuer claim value of `https://hostname/op1` is presented, the `RP1` configuration is selected unless the `rp2filter` applies to the request.
 [source, xml]
@@ -88,8 +88,8 @@ The following `server.xml` file example shows two Open ID connect client configu
         <feature>openidConnectClient-1.0</feature>
     </featureManager>
     ...
-    <openidConnectClient id="RP1" issuer="https://hostname/op1"  ... />
-    <openidConnectClient id="RP2" issuer="https://hostname/op2" authFilterRef="rp2filter" .../>
+    <openidConnectClient id="RP1" issuerIdentifier="https://hostname/op1"  ... />
+    <openidConnectClient id="RP2" issuerIdentifier="https://hostname/op2" authFilterRef="rp2filter" .../>
     <authFilter id="rp2filter">
     ...
     </authFilter>
@@ -100,9 +100,9 @@ The following `server.xml` file example shows two Open ID connect client configu
 Open Liberty selects the `openidConnectClient` configuration to use for a JWT request according to the following algorithm:
 
 1. If the authentication filter for a `openidConnectClient` configuration matches the request, choose that configuration.
-2. Check the issuer claim from the JWT against the `issuer` attributes from of all `openidConnectClient` elements. If the issuer claim from the JWT matches the `issuer` attribute in only one `openidConnectClient` configuration element, choose that configuration.
-3. If the issuer claim from the JWT matches the `issuer` attribute in multiple `openidConnectClient` configuration elements, choose the first configuration that matches.
-4. If the issuer claim from the JWT does not match the `issuer` attribute of any `openidConnectClient` configuration elements, choose one of the configuration elements in a nondeterministic manner.
+2. Check the issuer claim from the JWT against the `issuerIdentifier` attributes from of all `openidConnectClient` elements. If the issuer claim from the JWT matches the `issuerIdentifier` attribute in only one `openidConnectClient` configuration element, choose that configuration.
+3. If the issuer claim from the JWT matches the `issuerIdentifier` attribute in multiple `openidConnectClient` configuration elements, choose the first configuration that matches.
+4. If the issuer claim from the JWT does not match the `issuerIdentifier` attribute of any `openidConnectClient` configuration elements, choose one of the configuration elements in a nondeterministic manner.
 
 For more information about OpenID Connect Client, refer to the link:https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect Client specification].
 

--- a/posts/ja/2022-10-29-22.0.0.10.adoc
+++ b/posts/ja/2022-10-29-22.0.0.10.adoc
@@ -80,9 +80,9 @@ image::img/blog/blog_btn_stack.svg[Ask a question on Stack Overflow, align="cent
 
 22.0.0.10 以降、link:{url-prefix}/docs/latest/reference/feature/openidConnectClient-1.0.html[OpenID Connect Client 1.0] 機能は、JWT または JWS アクセス トークンの中の発行者クレームに応じて、複数の `openidConnectClient` 構成のうち、どの構成を使うか指定できるようになりました。以前のリリースでは、同じリソースに複数の発行者が使われている場合、複雑な認証フィルターを構成する必要がありました。このリリースから、OpenID Connect Client 1.0 機能は、必要な発行者ごとに、より単純な  `openidConnectClient` 要素で構成できるようになりました。
 
-A Liberty OpenID Connect Relying Party will automatically use the issuer claim from a JWT or JWS access token to select the `openidConnectClient` configuration with a matching `issuer` attribute. 
+A Liberty OpenID Connect Relying Party will automatically use the issuer claim from a JWT or JWS access token to select the `openidConnectClient` configuration with a matching `issuerIdentifier` attribute. 
 
-Liberty OpenID Connect Relying Party は、JWT または JWS アクセス トークンからの発行者クレームを自動的に使用して、一致する `issuer` 属性を持つ `openidConnectClient` 構成を選択します。
+Liberty OpenID Connect Relying Party は、JWT または JWS アクセス トークンからの発行者クレームを自動的に使用して、一致する `issuerIdentifier` 属性を持つ `openidConnectClient` 構成を選択します。
 
 The following `server.xml` file example shows two Open ID connect client configurations, with an link:{url-prefix}/docs/latest/authentication-filters.html[authentication filter] configured to route requests to the `RP2` configuration. If a request with an issuer claim value of `https://hostname/op1` is presented, the `RP1` configuration is selected unless the `rp2filter` applies to the request.
 
@@ -95,8 +95,8 @@ The following `server.xml` file example shows two Open ID connect client configu
         <feature>openidConnectClient-1.0</feature>
     </featureManager>
     ...
-    <openidConnectClient id="RP1" issuer="https://hostname/op1"  ... />
-    <openidConnectClient id="RP2" issuer="https://hostname/op2" authFilterRef="rp2filter" .../>
+    <openidConnectClient id="RP1" issuerIdentifier="https://hostname/op1"  ... />
+    <openidConnectClient id="RP2" issuerIdentifier="https://hostname/op2" authFilterRef="rp2filter" .../>
     <authFilter id="rp2filter">
     ...
     </authFilter>
@@ -107,9 +107,9 @@ The following `server.xml` file example shows two Open ID connect client configu
 Open Liberty は、以下のアルゴリズムに従って、JWT 要求に使用する `openidConnectClient` 構成を選択します。
 
 1. `openidConnectClient` 構成の認証フィルターが、リクエストと一致する場合は、フィルターの構成を優先します。
-2. すべての `openidConnectClient` 要素の `issuer` 属性に対して、JWT からの発行者クレーム(Issuer Claim)を確認します。 JWT からの発行者クレームが 1 つの`openidConnectClient` 構成要素のみの `issuer` 属性と一致する場合は、その構成を選択します。
-3. JWT からの発行者クレームが複数の `openidConnectClient` 構成要素の `issuer` 属性と一致する場合は、一致する最初の構成を選択します
-4. JWT からの issuer クレームがどの `openidConnectClient` 構成要素の `issuer` 属性とも一致しない場合は、構成要素の 1 つを非決定的な方法で選択します。
+2. すべての `openidConnectClient` 要素の `issuerIdentifier` 属性に対して、JWT からの発行者クレーム(Issuer Claim)を確認します。 JWT からの発行者クレームが 1 つの`openidConnectClient` 構成要素のみの `issuerIdentifier` 属性と一致する場合は、その構成を選択します。
+3. JWT からの発行者クレームが複数の `openidConnectClient` 構成要素の `issuerIdentifier` 属性と一致する場合は、一致する最初の構成を選択します
+4. JWT からの issuer クレームがどの `openidConnectClient` 構成要素の `issuerIdentifier` 属性とも一致しない場合は、構成要素の 1 つを非決定的な方法で選択します。
 
 OpenID Connect クライアントの詳細については、link:https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect クライアント仕様] を参照してください。
 


### PR DESCRIPTION
The https://openliberty.io/blog/2022/09/27/22.0.0.10.html#oidc post (and corresponding Japanese post) contains incorrect references to an `issuer` attribute in the `openidConnectClient` configuration element. Those references need to be updated to say `issuerIdentifier` instead.