### PR TITLE
webinar links added to 23.0.0.6 release post

### DIFF
--- a/posts/2023-06-27-23.0.0.6.adoc
+++ b/posts/2023-06-27-23.0.0.6.adoc
@@ -30,7 +30,7 @@ In link:{url-about}[Open Liberty] 23.0.0.6:
 
 Check out link:{url-prefix}/blog/?search=release&search!=beta[previous Open Liberty GA release blog posts].
 
-Join our live webinars with the Open Liberty development team. Get updates and answers to your questions. The webinars are scheduled to accommodate different timezones and will be similar in content. Register here:
+Join our live webinars with the Open Liberty development team. Get updates and answers to your questions. The webinars are scheduled to accommodate different timezones and are similar in content. They are recorded. Register here to join live or to access the recordings later:
 
 * link:https://community.ibm.com/community/user/wasdevops/events/event-description?CalendarEventKey=9165859e-ab3b-4439-9082-0187393599b9&CommunityKey=5c4ba155-561a-4794-9883-bb0c6164e14e&Home=%2fcommunity%2fuser%2fwasdevops%2fcommunities%2fcommunity-home%2frecent-community-events&utm_source=ol&utm_medium=article&utm_content=release23006[July 13, 9am-10:30am (ET)]
 * link:https://community.ibm.com/community/user/wasdevops/events/event-description?CalendarEventKey=3566b086-bbbb-4da2-9ace-0187390632c1&CommunityKey=5c4ba155-561a-4794-9883-bb0c6164e14e&Home=%2fcommunity%2fuser%2fwasdevops%2fcommunities%2fcommunity-home%2frecent-community-events&utm_source=ol&utm_medium=article&utm_content=release23006[July 20, 1pm-2:30pm (ET)]

--- a/posts/2023-06-27-23.0.0.6.adoc
+++ b/posts/2023-06-27-23.0.0.6.adoc
@@ -30,7 +30,7 @@ In link:{url-about}[Open Liberty] 23.0.0.6:
 
 Check out link:{url-prefix}/blog/?search=release&search!=beta[previous Open Liberty GA release blog posts].
 
-Join our live webinars with the Open Liberty development team. Get updates and answers to your questions. The webinars are scheduled to accommodate different timezones and are similar in content. They are recorded. Register here to join live or to access the recordings later:
+Join our live webinars with the Open Liberty development team. Get updates and answers to your questions. The webinars are scheduled to accommodate different timezones and are similar in content.  Register here to join live or to access the recordings later:
 
 * link:https://community.ibm.com/community/user/wasdevops/events/event-description?CalendarEventKey=9165859e-ab3b-4439-9082-0187393599b9&CommunityKey=5c4ba155-561a-4794-9883-bb0c6164e14e&Home=%2fcommunity%2fuser%2fwasdevops%2fcommunities%2fcommunity-home%2frecent-community-events&utm_source=ol&utm_medium=article&utm_content=release23006[July 13, 9am-10:30am (ET)]
 * link:https://community.ibm.com/community/user/wasdevops/events/event-description?CalendarEventKey=3566b086-bbbb-4da2-9ace-0187390632c1&CommunityKey=5c4ba155-561a-4794-9883-bb0c6164e14e&Home=%2fcommunity%2fuser%2fwasdevops%2fcommunities%2fcommunity-home%2frecent-community-events&utm_source=ol&utm_medium=article&utm_content=release23006[July 20, 1pm-2:30pm (ET)]

--- a/posts/2023-06-27-23.0.0.6.adoc
+++ b/posts/2023-06-27-23.0.0.6.adoc
@@ -30,6 +30,12 @@ In link:{url-about}[Open Liberty] 23.0.0.6:
 
 Check out link:{url-prefix}/blog/?search=release&search!=beta[previous Open Liberty GA release blog posts].
 
+Join our live webinars with the Open Liberty development team. Get updates and answers to your questions. The webinars are scheduled to accommodate different timezones and will be similar in content. Register here:
+
+* link:https://community.ibm.com/community/user/wasdevops/events/event-description?CalendarEventKey=9165859e-ab3b-4439-9082-0187393599b9&CommunityKey=5c4ba155-561a-4794-9883-bb0c6164e14e&Home=%2fcommunity%2fuser%2fwasdevops%2fcommunities%2fcommunity-home%2frecent-community-events&utm_source=ol&utm_medium=article&utm_content=release23006[July 13, 9am-10:30am (ET)]
+* link:https://community.ibm.com/community/user/wasdevops/events/event-description?CalendarEventKey=3566b086-bbbb-4da2-9ace-0187390632c1&CommunityKey=5c4ba155-561a-4794-9883-bb0c6164e14e&Home=%2fcommunity%2fuser%2fwasdevops%2fcommunities%2fcommunity-home%2frecent-community-events&utm_source=ol&utm_medium=article&utm_content=release23006[July 20, 1pm-2:30pm (ET)]
+
+
 [#run]
 
 == Run your apps using 23.0.0.6


### PR DESCRIPTION
Included UTM tags so we can track any visits from the release post to the registration page on IBM Community.

@mbroz2 See what you think of the format (for this particular case and for future release posts).