### PR TITLE
update user feature blog

### DIFF
--- a/posts/2022-07-06-user-feature-install.adoc
+++ b/posts/2022-07-06-user-feature-install.adoc
@@ -100,7 +100,7 @@ In the previous step, we created the Java class that implements the OSGi `Bundle
 <plugin>
     <groupId>org.apache.felix</groupId>
     <artifactId>maven-bundle-plugin</artifactId>
-    <version>3.3.0</version>
+    <version>5.1.8</version>
     <extensions>true</extensions>
     <configuration>
         <instructions>
@@ -125,29 +125,23 @@ Putting everything together, here is the entire `pom.xml` file:
 <modelVersion>4.0.0</modelVersion>
 <groupId>test.user.test.osgi</groupId>
 <artifactId>SimpleActivator</artifactId>
-<version>0.0.1-SNAPSHOT</version>
+<version>1.0.0-SNAPSHOT</version>
 <packaging>bundle</packaging>
 
-	<dependencies>
-		<dependency>
-	    <groupId>org.osgi</groupId>
-	    <artifactId>org.osgi.core</artifactId>
-	    <version>6.0.0</version>
-	    <scope>provided</scope>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.framework</artifactId>
+            <version>1.10.0</version>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>5.1.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -170,20 +164,19 @@ Run `mvn clean install` to build the bundle. Inside the bundle JAR file, you wil
 [source,txt]
 ----
 Manifest-Version: 1.0
-Bnd-LastModified: 1644446481175
-Build-Jdk: 11.0.10
-Built-By: jiwoolim
+Bnd-LastModified: 1695138711565
+Build-Jdk-Spec: 17
 Bundle-Activator: com.example.bundle.Activator
 Bundle-ManifestVersion: 2
 Bundle-Name: SimpleActivator
 Bundle-SymbolicName: com.example.bundle.Activator
 Bundle-Version: 1.0.0
-Created-By: Apache Maven Bundle Plugin
-Export-Package: com.example.bundle;uses:="org.osgi.framework";version
- ="1.0.0"
-Import-Package: org.osgi.framework;version="[1.8,2)"
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.6))"
-Tool: Bnd-3.3.0.201609221906
+Created-By: Apache Maven Bundle Plugin 5.1.8
+Export-Package: com.example.bundle;uses:="org.osgi.framework";version="1
+ .0.0"
+Import-Package: java.io,java.lang,org.osgi.framework;version="[1.10,2)"
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
+Tool: Bnd-6.3.1.202206071316
 ----
 
 '''
@@ -208,7 +201,7 @@ For details about the format of a feature manifest file, see link:https://www.ib
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>test.user.test.osgi</groupId>
-  <artifactId>SimpleActivatorESA-</artifactId>
+  <artifactId>SimpleActivatorESA</artifactId>
   <version>1.0.0-SNAPSHOT</version>
 
   <packaging>esa</packaging> <!-- set packaging type to esa -->
@@ -218,7 +211,7 @@ For details about the format of a feature manifest file, see link:https://www.ib
     <dependency>
 		<groupId>test.user.test.osgi</groupId>
     	<artifactId>SimpleActivator</artifactId>
-    	<version>0.0.1-SNAPSHOT</version>
+    	<version>1.0.0-SNAPSHOT</version>
 	</dependency>
   </dependencies>
 
@@ -277,7 +270,7 @@ Create a Bill of Materials (BOM) for the user feature ESA file. The BOM is a pom
 
   <groupId>test.user.test.osgi</groupId>
   <artifactId>features-bom</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>1.0</version>
   <packaging>pom</packaging>
   <name>user features bill of materials</name>
   <description>user features bill of materials</description>
@@ -287,9 +280,10 @@ Create a Bill of Materials (BOM) for the user feature ESA file. The BOM is a pom
     <dependencies>
       <dependency>
         <groupId>test.user.test.osgi</groupId>
-        <artifactId>SimpleActivatorESA-</artifactId>
+        <artifactId>SimpleActivatorESA</artifactId>
         <version>1.0.0-SNAPSHOT</version>
         <scope>runtime</scope>
+        <type>esa</type>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -338,7 +332,7 @@ Open the `${project.build.testOutputDirectory}/wlp/server.xml` file and add the 
      <dependency>
        <groupId>test.user.test.osgi</groupId>
        <artifactId>features-bom</artifactId>
-       <version>0.0.1-SNAPSHOT</version>
+       <version>1.0</version>
        <type>pom</type>
      </dependency>
    </dependencies>


### PR DESCRIPTION
The issue was found in https://github.com/OpenLiberty/ci.maven/issues/1615
Initial blog was missing artifact properties `<type>esa</type>` in the `features-bom` file. Also updated old plugin's versions to newer versions.
