### PR TITLE
Update 2024-02-27-24.0.0.2.adoc (staging)

### DIFF
--- a/posts/ja/2024-02-27-24.0.0.2.adoc
+++ b/posts/ja/2024-02-27-24.0.0.2.adoc
@@ -70,7 +70,7 @@ link:{url-prefix}/guides/maven-intro.html[Maven]を使うときは下記の設�
 </plugin>
 ----
 
-link:{url-prefix}/guides/gradle-intro.html[Gradle]の場合は、`build.gradle`ファイルに以下をインクルードします。
+link:{url-prefix}/guides/gradle-intro.html[Gradle]の場合は、`build.gradle` ファイルに以下をインクルードします。
 
 [source,gradle]
 ----


### PR DESCRIPTION
Add a trailing space so "build.gradle" is styled like a code block

# Before
<img width="309" alt="image" src="https://github.com/OpenLiberty/blogs/assets/31117513/090e6816-b8b7-4d26-a781-8d6fdd598b9c">

# After
<img width="279" alt="image" src="https://github.com/OpenLiberty/blogs/assets/31117513/b0a171b8-c9d5-434f-8b87-96e613b47f30">
