### PR TITLE
Update Database SSL primer with updates to Oracle JDBC 23

### DIFF
--- a/posts/2021-06-04-database-ssl-primer.adoc
+++ b/posts/2021-06-04-database-ssl-primer.adoc
@@ -229,7 +229,7 @@ To establish trust, configure one of the following options:
 
 > NOTE: the `ewallet.p12` file contains additional encrypted data that the Oracle driver needs to establish the TLS connection to the database.  As such, the default Security Providers shipped with the Java JRE will fail to read this file. If using the `ewallet.p12` keystore users will need to add the Oracle PKI driver to their JVM native liberty path, and add the `oracle.security.pki.OraclePKIProvider.OraclePKIProvider` class to position 1 of their security provides.
 
-> NOTE: prior to Oracle JDBC 23 the Oracle PKI driver (`oraclepki.jar`) depended on the `osdt_core.jar` and `osdt_cert.jar` files for Oracle Wallet support. After Oracle JDBC 23, the Oracle PKI driver includes these dependencies and the files are no longer required.
+> NOTE: prior to Oracle JDBC 23 the Oracle PKI driver (`oraclepki.jar`) depended on the `osdt_core.jar` and `osdt_cert.jar` files for Oracle Wallet support. After Oracle JDBC 23, the Oracle PKI driver includes the functionality previously provided by `osdt_core.jar` and `osdt_cert.jar` and therefore these files are no longer required.
 
 For more information, see  https://www.oracle.com/technetwork/topics/wp-oracle-jdbc-thin-ssl-130128.pdf[SSL With Oracle JDBC Thin Driver].
 

--- a/posts/2021-06-04-database-ssl-primer.adoc
+++ b/posts/2021-06-04-database-ssl-primer.adoc
@@ -229,7 +229,7 @@ To establish trust, configure one of the following options:
 
 > NOTE: the `ewallet.p12` file contains additional encrypted data that the Oracle driver needs to establish the TLS connection to the database.  As such, the default Security Providers shipped with the Java JRE will fail to read this file. If using the `ewallet.p12` keystore users will need to add the Oracle PKI driver to their JVM native liberty path, and add the `oracle.security.pki.OraclePKIProvider.OraclePKIProvider` class to position 1 of their security provides.
 
-> NOTE: prior to Oracle JDBC 23 the Oracle PKI driver (oraclepki.jar) depended on osdt_core.jar and osdt_cert.jar for Oracle Wallet support. After Oracle JDBC 23 the Oracle PKI driver includes these dependencies and are no longer required.
+> NOTE: prior to Oracle JDBC 23 the Oracle PKI driver (`oraclepki.jar`) depended on the `osdt_core.jar` and `osdt_cert.jar` files for Oracle Wallet support. After Oracle JDBC 23, the Oracle PKI driver includes these dependencies and the files are no longer required.
 
 For more information, see  https://www.oracle.com/technetwork/topics/wp-oracle-jdbc-thin-ssl-130128.pdf[SSL With Oracle JDBC Thin Driver].
 

--- a/posts/2021-06-04-database-ssl-primer.adoc
+++ b/posts/2021-06-04-database-ssl-primer.adoc
@@ -229,7 +229,7 @@ To establish trust, configure one of the following options:
 
 > NOTE: the `ewallet.p12` file contains additional encrypted data that the Oracle driver needs to establish the TLS connection to the database.  As such, the default Security Providers shipped with the Java JRE will fail to read this file. If using the `ewallet.p12` keystore users will need to add the Oracle PKI driver to their JVM native liberty path, and add the `oracle.security.pki.OraclePKIProvider.OraclePKIProvider` class to position 1 of their security provides.
 
-> NOTE: prior to Oracle JDBC 23 the Oracle PKI driver (`oraclepki.jar`) depended on the `osdt_core.jar` and `osdt_cert.jar` files for Oracle Wallet support. After Oracle JDBC 23, the Oracle PKI driver includes the functionality previously provided by `osdt_core.jar` and `osdt_cert.jar` and therefore these files are no longer required.
+> NOTE: prior to Oracle JDBC 23, the Oracle PKI driver (`oraclepki.jar`) depended on the `osdt_core.jar` and `osdt_cert.jar` files for Oracle Wallet support. After Oracle JDBC 23, the Oracle PKI driver includes the functionality that was previously provided by `osdt_core.jar` and `osdt_cert.jar` and therefore these files are no longer required.
 
 For more information, see  https://www.oracle.com/technetwork/topics/wp-oracle-jdbc-thin-ssl-130128.pdf[SSL With Oracle JDBC Thin Driver].
 

--- a/posts/2021-06-04-database-ssl-primer.adoc
+++ b/posts/2021-06-04-database-ssl-primer.adoc
@@ -160,7 +160,7 @@ For more information, see https://jdbc.postgresql.org/documentation/head/connect
 
 === Oracle
 
-The following `server.xml` example configures two Oracle data sources, each of which establishes trust in a different way:
+The following `server.xml` example configures three Oracle data sources, each of which establishes trust in a different way:
 
 [source,xml]
 ----
@@ -168,6 +168,13 @@ The following `server.xml` example configures two Oracle data sources, each of w
   <featureManager>
     <feature>jdbc-4.2</feature>
   </featureManager>
+
+  <jdbcDriver id="jdbcLib">
+    <library>
+      <fileset dir="${shared.resource.dir}/ssl/" 
+               includes="ojdbc8.jar oraclepki.jar osdt_core.jar osdt_cert.jar"/>
+    </library>
+  </jdbcDriver>
 
   <!-- General TLS connection properties -->
   <variable name="oracle.tls.props" value="oracle.net.ssl_version=1.2;oracle.net.ssl_server_dn_match=false;oracle.net.authentication_services=TCPS;"/>
@@ -221,6 +228,8 @@ To establish trust, configure one of the following options:
 - Option 3: To establish trust by using Oracle Wallets and Java keystore and truststore files, use the `javax.net.ssl.*` connection properties.
 
 > NOTE: the `ewallet.p12` file contains additional encrypted data that the Oracle driver needs to establish the TLS connection to the database.  As such, the default Security Providers shipped with the Java JRE will fail to read this file. If using the `ewallet.p12` keystore users will need to add the Oracle PKI driver to their JVM native liberty path, and add the `oracle.security.pki.OraclePKIProvider.OraclePKIProvider` class to position 1 of their security provides.
+
+> NOTE: prior to Oracle JDBC 23 the Oracle PKI driver (oraclepki.jar) depended on osdt_core.jar and osdt_cert.jar for Oracle Wallet support. After Oracle JDBC 23 the Oracle PKI driver includes these dependencies and are no longer required.
 
 For more information, see  https://www.oracle.com/technetwork/topics/wp-oracle-jdbc-thin-ssl-130128.pdf[SSL With Oracle JDBC Thin Driver].
 


### PR DESCRIPTION
- Oracle JDBC 23 no longer requires osdt_core and osdt_cert dependencies for Oracle Wallet support