### PR TITLE
Takakiyo san review for 24.0.0.4 

### DIFF
--- a/posts/ja/2024-04-23-24.0.0.4.adoc
+++ b/posts/ja/2024-04-23-24.0.0.4.adoc
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: 「24.0.0.4 での Java SE 22 サポート」
+title: 「24.0.0.4 で Java SE 22 サポート」
 # Do NOT change the categories section
 categories: blog
 author_picture: https://avatars3.githubusercontent.com/ramkumar-k-9286
@@ -16,10 +16,10 @@ additional_authors:
   image: https://avatars0.githubusercontent.com/una-tapa
 blog-available-in-languages:
 - lang: en
-  path: /blog/2024/04/23/2024-04-23-24.0.0.4.html
+  path: /blog/2024/04/23/2024/04/23/24.0.0.4.html
 
 ---
-= Java SE 22 support in 24.0.0.4
+= 24.0.0.4でJava SE 22をサポート
 Ramkumar K <https://github.com/ramkumar-k-9286>
 :imagesdir: /
 :url-prefix:
@@ -91,21 +91,20 @@ image::img/blog/blog_btn_stack_ja.svg[Stack Overflow で質問する、align=&qu
 
 Java 22 は、2024 年 3 月にリリースされた Java SE の最新リリースです。以前のバージョンの Java に比べて新機能と拡張機能が含まれています。ただし、Java 22 は長期サポート (LTS) リリースではないため、次のバージョンの Java がサポートされるとサポートは終了します。いくつかの新機能と変更点が提供されており、ぜひご自身でご確認ください。
 
-次のリンクを確認してくださいlink：https://openjdk.org/projects/jdk/22/[Java 22 の機能変更]：
+link:https://openjdk.org/projects/jdk/22/[Java 22 の機能変更]を確認してください：
 
 * 423: link:https://openjdk.org/jeps/423[G1 のリージョン固定]
 * 447: link:https://openjdk.org/jeps/447[super(...) の前のステートメント (プレビュー)]
-* 454: link:https://openjdk.org/jeps/454[外部関数とメモリ API]
-* 456: link:https://openjdk.org/jeps/456[名前のない変数とパターン]
+* 454: link:https://openjdk.org/jeps/454[Foreign Function＆Memory API]
+* 456: link:https://openjdk.org/jeps/456[無名変数と無名パターン]
 * 457: link:https://openjdk.org/jeps/457[クラスファイル API (プレビュー)]
-* 458: link:https://openjdk.org/jeps/458[複数ファイルのソースコード プログラムを起動]
+* 458: link:https://openjdk.org/jeps/458[複数ファイルのソースコードのプログラム起動]
 * 459: link:https://openjdk.org/jeps/459[文字列テンプレート (第 2 プレビュー)]
 * 460: link:https://openjdk.org/jeps/460[ベクターAPI (セブンスインキュベータ)]
-* 461: link:https://openjdk.org/jeps/461[ストリーム ギャザラー (プレビュー)]
+* 461: link:https://openjdk.org/jeps/461[Stream Gatherers (プレビュー)]
 * 462: link:https://openjdk.org/jeps/462[構造化並行性 (第 2 プレビュー)]
-* 463: link:https://openjdk.org/jeps/463[暗黙的に宣言されたクラスとインスタンスのメインメソッド (第 2 プレビュー)]
+* 463: link:https://openjdk.org/jeps/463[暗黙的に宣言されたクラスとインスタンスのmainメソッド (第 2 プレビュー)]
 * 464: link:https://openjdk.org/jeps/464[スコープ値 (第 2 プレビュー)]
-
 
 
 今すぐ Open Liberty の Java 22 の新しい変更を活用して、お気に入りのサーバー ランタイムでアプリケーション、マイクロサービス、ランタイム環境を確認する時間を増やしましょう。


### PR DESCRIPTION
タイトル「Java SE 22 support in 24.0.0.4」→「24.0.0.4でJava SE 22をサポート」
enのリンクが壊れてます。
- lang: en
  path: /blog/2024/04/23/2024-04-23-24.0.0.4.html
↓
- lang: en
  path: /blog/2024/04/23/24.0.0.4.html
「== Open Liberty での Java 22 のサポート」でlinkに続くコロンが全角になっているため，リンクが崩れています。
次のリンクを確認してくださいlink：https://openjdk.org/projects/jdk/22/[Java 22 の機能変更]：
↓
次のリンクを確認してくださいlink:https://openjdk.org/projects/jdk/22/[Java 22 の機能変更]：
JEPの名称について，日本で広く使われている名称に合わせるとこのようになります。
「外部関数とメモリ API」→「Foreign Function＆Memory API」（翻訳されないことが多いです）
「名前のない変数とパターン」→「無名変数と無名パターン」
「複数ファイルのソースコード プログラムを起動」→「複数ファイルのソースコードのプログラム起動」（微妙ですが・・・）
「ストリーム ギャザラー」→「Stream Gatherers」（翻訳されないことが多いです）
「暗黙的に宣言されたクラスとインスタンスのメインメソッド」→「暗黙的に宣言されたクラスとインスタンスのmainメソッド」（mainは翻訳されないです）