### PR TITLE
simplify and differentiate examples

### DIFF
--- a/posts/2020-04-22-http-response-compression.adoc
+++ b/posts/2020-04-22-http-response-compression.adoc
@@ -87,10 +87,7 @@ Configuring compression for individual HTTP endpoints:
 <httpEndpoint id="defaultHttpEndpoint"
                         httpPort="9080"
                         httpsPort="9443">
-    <compression serverPreferredAlgorithm="deflate|gzip|x-gzip|zlib|identity|none">
-          <types>+application/*</types>
-          <types>-text/plain</types>
-    </compression>
+    <compression/>
 </httpEndpoint>
 ----
 
@@ -110,11 +107,22 @@ Configuring compression for all HTTP endpoints:
                         compressionRef="myCompressionID">
     </httpEndpoint>
 
-    <compression id="myCompressionID" serverPreferredAlgorithm="deflate|gzip|x-gzip|zlib|identity|none">
+    <compression id="myCompressionID"/>
+----
+
+The `types` attribute in the following example adds all application content types and removes the `text/plain` content type from the `text/*` default.
+
+[source,xml]
+----
+<httpEndpoint id="defaultHttpEndpoint"
+                        httpPort="9080"
+                        httpsPort="9443">
+    <compression>
               <types>+application/*</types>
               <types>-text/plain</types>
-    </compression>
+     </compression>
+</httpEndpoint>
 ----
-The `types` attribute in the examples adds all application content types and removes the `text/plain` content type from the `text/*` default.
+
 
 With this new `<compression>` configuration option, you can configure Open Liberty to compress HTTP responses before returning them to clients. This reduces bandwidth and the time taken for HTTP clients to get responses.


### PR DESCRIPTION
The preferred algorithm value was the syntax, not a valid value. It's also relatively obscure function.

Simplify the examples and make the content-type one dedicated in a third example.