### PR TITLE
Japanese blog 24.0.0.8

### DIFF
--- a/posts/2024-08-13-24.0.0.8.adoc
+++ b/posts/2024-08-13-24.0.0.8.adoc
@@ -10,6 +10,8 @@ seo-description: This release introduces versionless features for the Jakarta EE
 blog_description: This release introduces versionless features for the Jakarta EE, Java EE, and MicroProfile platforms. It also includes updates to eliminate unnecessary audit records.
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
+- lang: ja
+  path: /blog/ja/2024/08/13/2024-08-13-24.0.0.8.html
 ---
 = Simplify your configuration with versionless features in 24.0.0.8
 David Mueller <https://github.com/dmuelle>

--- a/posts/2024-08-13-24.0.0.8.adoc
+++ b/posts/2024-08-13-24.0.0.8.adoc
@@ -71,7 +71,7 @@ Check out link:{url-prefix}/blog/?search=release&search!=beta[previous Open Libe
 
 == Develop and run your apps using 24.0.0.8
 
-If you're using link:{url-prefix}/guides/maven-intro.html[Maven], include the following in your `pom.xml` file:
+If you're using link:{url-prefix}/guides/maven-intro.html[Maven], include the following code in your `pom.xml` file:
 
 [source,xml]
 ----

--- a/posts/2024-08-13-24.0.0.8.adoc
+++ b/posts/2024-08-13-24.0.0.8.adoc
@@ -12,7 +12,7 @@ open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
 blog-available-in-languages:
 - lang: ja
-  path: /blog/ja/2024/08/13/2024-08-13-24.0.0.8.html
+  path: ja/blog/2024/08/13/2024-08-13-24.0.0.8.html
 ---
 = Simplify your configuration with versionless features in 24.0.0.8
 David Mueller <https://github.com/dmuelle>

--- a/posts/2024-08-13-24.0.0.8.adoc
+++ b/posts/2024-08-13-24.0.0.8.adoc
@@ -10,6 +10,7 @@ seo-description: This release introduces versionless features for the Jakarta EE
 blog_description: This release introduces versionless features for the Jakarta EE, Java EE, and MicroProfile platforms. It also includes updates to eliminate unnecessary audit records.
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
+blog-available-in-languages:
 - lang: ja
   path: /blog/ja/2024/08/13/2024-08-13-24.0.0.8.html
 ---

--- a/posts/2024-08-13-24.0.0.8.adoc
+++ b/posts/2024-08-13-24.0.0.8.adoc
@@ -12,7 +12,7 @@ open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
 blog-available-in-languages:
 - lang: ja
-  path: ja/blog/2024/08/13/24.0.0.8.html
+  path: /ja/blog/2024/08/13/24.0.0.8.html
 ---
 = Simplify your configuration with versionless features in 24.0.0.8
 David Mueller <https://github.com/dmuelle>

--- a/posts/2024-08-13-24.0.0.8.adoc
+++ b/posts/2024-08-13-24.0.0.8.adoc
@@ -12,7 +12,7 @@ open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
 blog-available-in-languages:
 - lang: ja
-  path: ja/blog/2024/08/13/2024-08-13-24.0.0.8.html
+  path: ja/blog/2024/08/13/24.0.0.8.html
 ---
 = Simplify your configuration with versionless features in 24.0.0.8
 David Mueller <https://github.com/dmuelle>

--- a/posts/ja/2024-08-13-24.0.0.8.adoc
+++ b/posts/ja/2024-08-13-24.0.0.8.adoc
@@ -10,17 +10,15 @@ seo-description: このリリースでは、Jakarta EE、Java EE、MicroProfile 
 blog_description: このリリースでは、Jakarta EE、Java EE、MicroProfile フィーチャーのバージョンレス機能が導入されています。また、不要な監査レコードを排除するための更新も含まれています。
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
-additional_authors: 
+additional_authors:
 - name: 高宮 裕子 (翻訳)
   github: https://github.com/una-tapa
   image: https://avatars0.githubusercontent.com/una-tapa
 blog-available-in-languages:
 - lang: en
   path: /blog/2024/08/13/2024-08-13-24.0.0.8.html
-
 ---
 = 24.0.0.8 のバージョンレス機能で設定を簡素化
-
 David Mueller <https://github.com/dmuelle>
 
 :imagesdir: /
@@ -202,4 +200,3 @@ link:https://openliberty.io/guides/#configuration[構成] カテゴリに新し�
 
 
 Open Liberty 24.0.0.7は、<<run,Maven, Gradle, Docker, and as a downloadable archive>>のリンクからお試しいただけます。
-

--- a/posts/ja/2024-08-13-24.0.0.8.adoc
+++ b/posts/ja/2024-08-13-24.0.0.8.adoc
@@ -16,7 +16,7 @@ additional_authors:
   image: https://avatars0.githubusercontent.com/una-tapa
 blog-available-in-languages:
 - lang: en
-  path: /blog/2024/08/13/2024-08-13-24.0.0.8.html
+  path: /blog/2024/08/13/24.0.0.8.html
 ---
 = 24.0.0.8 のバージョンレス機能で設定を簡素化
 David Mueller <https://github.com/dmuelle>

--- a/posts/ja/2024-08-13-24.0.0.8.adoc
+++ b/posts/ja/2024-08-13-24.0.0.8.adoc
@@ -164,8 +164,7 @@ Open Liberty では、アプリケーションに必要な特定のバージョ�
 [#audit]
 == 不要なRESTハンドラーレコードの生成を避けるためにAudit 2.0機能を使用する
 
-The 24.0.0.8 release introduces the link:{url-prefix}/docs/latest/reference/feature/audit-2.0.html[Audit 2.0 feature] (`audit-2.0`). The feature is designed for users who are not using REST Handler applications.
-Audit 1.0 機能 (`audit-1.0`) と同じ監査レコードを提供しますが、REST ハンドラー アプリケーションのレコードは生成されません。
+この24.0.0.8 リリースでは、link:{url-prefix}/docs/latest/reference/feature/audit-2.0.html[Audit 2.0 機能] (`audit-2.0`)が導入されました。この機能はRESTハンドラ・アプリケーションを使用していないユーザー向けに設計されています。Audit 1.0 機能 (`audit-1.0`) と同じ監査レコードを提供しますが、REST ハンドラー アプリケーションのレコードは生成されません。
 
 REST ハンドラー アプリケーションの監査レコードを保持する必要がある場合は、引き続き Audit 1.0 機能を使用できます。
 
@@ -188,8 +187,6 @@ REST ハンドラー アプリケーションの監査レコードを保持す�
 
 [#guides]
 == 新しいガイド: CI/CD 用の環境固有のマイクロサービス構成の外部化
-
-A new guide is available under the link:https://openliberty.io/guides/#configuration[Configuration] category: link:https://openliberty.io/guides/microprofile-config-profile.html[Externalizing environment-specific microservice configuration for CI/CD]. You'll learn how to use MicroProfile Config's configuration profiles to externalize configurations for different phases of the CI/CD lifecycle.
 
 link:https://openliberty.io/guides/#configuration[構成] カテゴリに新しいガイドがあります: link:https://openliberty.io/guides/microprofile-config-profile.html[CI/CDのための環境固有のマイクロサービス構成の外部化]です。MicroProfile Config の構成プロファイルを使用して、CI/CD ライフサイクルのさまざまなフェーズの構成を外部化する方法を学びます。
 

--- a/posts/ja/2024-08-13-24.0.0.8.adoc
+++ b/posts/ja/2024-08-13-24.0.0.8.adoc
@@ -1,0 +1,205 @@
+---
+layout: post
+title: 「24.0.0.8 のバージョンレス機能で設定を簡素化」
+# Do NOT change the categories section
+categories: blog
+author_picture: https://avatars3.githubusercontent.com/dmuelle
+author_github: https://github.com/dmuelle
+seo-title: 24.0.0.8 のバージョンレス機能で設定を簡素化 - OpenLiberty.io
+seo-description: このリリースでは、Jakarta EE、Java EE、MicroProfile フィーチャーのバージョンレス機能が導入されています。また、不要な監査レコードを排除するための更新も含まれています。
+blog_description: このリリースでは、Jakarta EE、Java EE、MicroProfile フィーチャーのバージョンレス機能が導入されています。また、不要な監査レコードを排除するための更新も含まれています。
+open-graph-image: https://openliberty.io/img/twitter_card.jpg
+open-graph-image-alt: Open Liberty Logo
+additional_authors: 
+- name: 高宮 裕子 (翻訳)
+  github: https://github.com/una-tapa
+  image: https://avatars0.githubusercontent.com/una-tapa
+blog-available-in-languages:
+- lang: en
+  path: /blog/2024/08/13/2024-08-13-24.0.0.8.html
+
+---
+= 24.0.0.8 のバージョンレス機能で設定を簡素化
+
+David Mueller <https://github.com/dmuelle>
+
+:imagesdir: /
+:url-prefix:
+:url-about: /
+//Blank line here is necessary before starting the body of the post.
+
+このリリースでは、Jakarta EE、Java EE、MicroProfile フィーチャーのバージョンレス機能が導入されています。また、不要な監査レコードを排除するための更新も含まれています。
+
+
+In link:{url-about}[Open Liberty] 24.0.0.8:
+
+* <<versionless, バージョンレスの Jakarta EE、Java EE、MicroProfile 機能で機能選択を効率化>>
+
+* <<audit,不要なRESTハンドラーレコードの生成を避けるためにAudit 2.0機能を使用する>>
+
+
+
+// // // // // // // //
+// If there were updates to guides since last release, keep the following, otherwise remove section.
+// // // // // // // //
+ランタイムに追加された新機能や機能に加えて、 <<guides, 新しいガイド: CI/CD 用の環境固有のマイクロサービス構成の外部化>>を追加しました。
+
+
+// // // // // // // //
+// In the preceding section:
+// Replace the TAG_X with a short label for the feature in lower-case, eg: mp3
+// Replace the FEATURE_1_HEADING with heading the feature section, eg: MicroProfile 3.3
+// Where the updates are grouped as sub-headings under a single heading
+//   (eg all the features in a MicroProfile release), provide sub-entries in the list;
+//   eg replace SUB_TAG_1 with mpr, and SUB_FEATURE_1_HEADING with
+//   Easily determine HTTP headers on outgoing requests (MicroProfile Rest Client 1.4)
+// // // // // // // //
+
+link:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A24008+label%3A%22release+bug%22[24.0.0.8のバグ修正リスト]はこちらです。
+
+link:{url-prefix}/blog/?search=release&search!=beta[過去のOpen Libertyのリリース・ブログはこちら]からご覧ください。
+
+
+[#run]
+
+// // // // // // // //
+// LINKS
+//
+// OpenLiberty.io site links:
+// link:{url-prefix}/guides/maven-intro.html[Maven]
+//
+// Off-site links:
+//link:https://openapi-generator.tech/docs/installation#jar[Download Instructions]
+//
+// IMAGES
+//
+// Place images in ./img/blog/
+// Use the syntax:
+// image::/img/blog/log4j-rhocp-diagrams/current-problem.png[Logging problem diagram,width=70%,align="center"]
+// // // // // // // //
+
+== 24.0.0.8 を使用してアプリを開発および実行する
+
+link:{url-prefix}/guides/maven-intro.html[Maven]を使用している場合は、`pom.xml` ファイルに以下を含めます。
+
+[source,xml]
+----
+<plugin>
+    <groupId>io.openliberty.tools</groupId>
+    <artifactId>liberty-maven-plugin</artifactId>
+    <version>3.10.3</version>
+</plugin>
+----
+
+または、link:{url-prefix}/guides/gradle-intro.html[Gradle] の場合は、`build.gradle` ファイルに次の内容を含めます。
+
+[source,gradle]
+----
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.8.3'
+    }
+}
+apply plugin: 'liberty'
+----
+
+または、link:{url-prefix}/docs/latest/container-images.html[コンテナ イメージ] を使用している場合:
+
+[source]
+----
+FROM icr.io/appcafe/open-liberty
+----
+
+または、link:{url-prefix}/start/[ダウンロード・ページ]をご覧ください。
+
+link:https://plugins.jetbrains.com/plugin/14856-liberty-tools[IntelliJ IDEA]、link:https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext[Visual Studio Code]、または link:https://marketplace.eclipse.org/content/liberty-tools[Eclipse IDE]を使用している場合は、オープンソースの link:https://openliberty.io/docs/latest/develop-liberty-tools.html[Liberty 開発者ツール] を活用して、IDE 内から効果的な開発、テスト、デバッグ、アプリケーション管理を行うこともできます。
+
+[link=https://stackoverflow.com/tags/open-liberty]
+image::img/blog/blog_btn_stack_ja.svg[Ask a question on Stack Overflow, align="center"]
+
+
+[#versionless]
+== バージョンレスの Jakarta EE、Java EE、MicroProfile 機能で機能選択を効率化
+
+Open Liberty では、アプリケーションに必要な特定のバージョンの機能のみを構成します。この構成可能な設計パターンにより、実行時のリソース要件が最小限に抑えられ、アプリケーションの起動時間が短縮されます。ただし、機能のどのバージョンがアプリケーション構成の残りの部分と互換性があるかが常にわかるとは限りません。以前のリリースでは、正しいバージョンを判断するには、通常、実験、推測、機能ドキュメントの詳細な調査が必要でした。24.0.0.8 以降では、バージョンレス機能によってバージョン選択が自動化されるため、互換性の問題を気にすることなくアプリケーション開発に集中できます。
+
+たとえば、`server.xml` ファイルで `servlet-6.0` を指定して、他のどの機能バージョンが Servlet 6.0 と互換性があるかを調べる代わりに、フィーチャー バージョンと `servlet` を指定できます。指定したフィーチャーによって、バージョンのないすべての機能が互換性のあるバージョンに解決されます。
+
+次の `server.xml` ファイル構成では、`servlet`、`jpa`、および `jaxrs` に対して定義されている関連するバージョンレス機能を備えた `javaee-8.0` の Java EE フィーチャーを使用します。
+
+[source,xml]
+----
+    <!-- Enable features -->
+    <featureManager>
+        <platform>javaee-8.0</platform>
+        <feature>servlet</feature>
+        <feature>jpa</feature>
+        <feature>jaxrs</feature>
+    </featureManager>
+----
+
+この例では、フィーチャー要素として `microProfile-5.0` を指定して、バージョンレス MicroProfile 機能を有効にします。
+
+[source,xml]
+----
+    <!-- Enable features -->
+    <featureManager>
+        <platform>microProfile-5.0</platform>
+        <feature>mpHealth</feature>
+        <feature>mpMetrics</feature>
+    </featureManager>
+----
+
+注: Liberty Maven および Gradle ビルド プラグインは、バージョンレス機能またはフィーチャー定義をまだサポートしていません。
+
+利用可能なプラットフォームとバージョンレス機能の詳細については、link:{url-prefix}/docs/latest/reference/feature/versionless-features.html[Open Liberty docs]をご覧ください。今後のバージョンレス機能とプラットフォームのリリースにご期待ください。
+
+
+// // // // DO NOT MODIFY THIS COMMENT BLOCK <GHA-BLOG-TOPIC> // // // //
+// Blog issue: https://github.com/OpenLiberty/open-liberty/issues/29211
+// Contact/Reviewer: wrodrig
+// // // // // // // //
+
+[#audit]
+== 不要なRESTハンドラーレコードの生成を避けるためにAudit 2.0機能を使用する
+
+The 24.0.0.8 release introduces the link:{url-prefix}/docs/latest/reference/feature/audit-2.0.html[Audit 2.0 feature] (`audit-2.0`). The feature is designed for users who are not using REST Handler applications.
+Audit 1.0 機能 (`audit-1.0`) と同じ監査レコードを提供しますが、REST ハンドラー アプリケーションのレコードは生成されません。
+
+REST ハンドラー アプリケーションの監査レコードを保持する必要がある場合は、引き続き Audit 1.0 機能を使用できます。
+
+アプリケーションで Audit 2.0 機能を有効にするには、`server.xml` ファイルに次のコードを追加します。
+
+[source,xml]
+----
+<featureManager>
+    <feature>audit-2.0</feature>
+</featureManager>
+----
+
+
+// DO NOT MODIFY THIS LINE. </GHA-BLOG-TOPIC>
+
+// // // // DO NOT MODIFY THIS COMMENT BLOCK <GHA-BLOG-TOPIC> // // // //
+// Blog issue: https://github.com/OpenLiberty/open-liberty/issues/29185
+// Contact/Reviewer: gkwan-ibm
+// // // // // // // /
+
+[#guides]
+== 新しいガイド: CI/CD 用の環境固有のマイクロサービス構成の外部化
+
+A new guide is available under the link:https://openliberty.io/guides/#configuration[Configuration] category: link:https://openliberty.io/guides/microprofile-config-profile.html[Externalizing environment-specific microservice configuration for CI/CD]. You'll learn how to use MicroProfile Config's configuration profiles to externalize configurations for different phases of the CI/CD lifecycle.
+
+link:https://openliberty.io/guides/#configuration[構成] カテゴリに新しいガイドがあります: link:https://openliberty.io/guides/microprofile-config-profile.html[CI/CDのための環境固有のマイクロサービス構成の外部化]です。MicroProfile Config の構成プロファイルを使用して、CI/CD ライフサイクルのさまざまなフェーズの構成を外部化する方法を学びます。
+
+// DO NOT MODIFY THIS LINE. </GHA-BLOG-TOPIC>
+
+
+== Open Liberty 24.0.0.8 を今すぐ入手
+
+
+Open Liberty 24.0.0.7は、<<run,Maven, Gradle, Docker, and as a downloadable archive>>のリンクからお試しいただけます。
+


### PR DESCRIPTION
OpenLiberty Blog 24.0.0.8 translation to Japanese.  It is ready for publish after incorporating  [Kurokawa-san's review comments](https://github.com/OpenLiberty/blogs/commit/039c2047f521edcf3c1153362ba9c7f9a5d4948d) .  The draft site reflected the change requests from him.  

There’s no rush to publish right now. If we release two more blogs—24.0.0.9 and 24.0.0.10—the 24.0.0.10 post will mark our 2-year Japanese blog anniversary.  There will be TXC Japan on 11/27/2024.  Our goal is to have the blog site fully presentable by then.