### PR TITLE
Japanese blog two year celebration

### DIFF
--- a/posts/ja/2024-12-16-jblog-two-year-celebration.adoc
+++ b/posts/ja/2024-12-16-jblog-two-year-celebration.adoc
@@ -3,8 +3,8 @@ layout: post
 title: OpenLibertyの日本語ブログが2周年を迎えました
 # Do NOT change the categories section
 categories: blog
-author_picture: https://avatars3.githubusercontent.com/dmuelle
-author_github: https://github.com/dmuelle
+author_picture: https://avatars3.githubusercontent.com/una-tapa
+author_github: https://github.com/una-tapa
 seo-title: OpenLibertyの日本語ブログが2周年を迎えました
 seo-description: Open Libertyの日本語ブログが2022年にスタートしてから2周年を迎えました。これまでの人気記事ランキングと、貢献してくれたコントリビューターを紹介します。
 blog_description: Open Libertyの日本語ブログが2022年にスタートしてから2周年を迎えました。これまでの人気記事ランキングと、貢献してくれたコントリビューターを紹介します。
@@ -29,7 +29,7 @@ additional_authors:
 ---
 
 = OpenLibertyの日本語ブログが2周年を迎えました
-高宮　裕子 <https://github.com/unatapa>
+高宮　裕子 <https://github.com/una-tapa>
 :imagesdir: /
 :url-prefix:
 :url-about: /
@@ -108,7 +108,7 @@ Open Libertyの日本語ブログでは、最新リリースに関する技術�
 
 翻訳記事や技術情報を提供してくれているコントリビューターのみなさんから、一言いただいてきました。
 
-link:https://github.com/MiyukaNishio[西尾実優香さん]
+link:https://www.linkedin.com/in/miyuka-nishio[西尾実優香さん]
 
 こんにちは、IBMに入社して2年目の西尾実優香です。現在はWebSphere Libertyのテクニカルセールスとして、プリセールス活動やコミュニティ運営に携わっています。
 IBMに入社前は会計学を専門としていたため、Java開発の経験はほとんどありませんでしたが、上司からスキルアップの一環としてOpen Libertyのブログ翻訳に参加する機会をいただきました。
@@ -116,7 +116,7 @@ IBMに入社前は会計学を専門としていたため、Java開発の経験�
 まだまだ学ぶことが多いですが、今後も技術者として成長し、Open Libertyプロジェクトに貢献できるよう努力していきます。
 
 
-link:https://github.com/babatch[馬場 剛さん]
+link:https://www.linkedin.com/in/tsuyoshi-baba-babatch[馬場 剛さん]
 
 1998年に日本アイ・ビー・エム株式会社 (IBMJ) へ入社後、同年末の WebSphere Application Server V1.1 の日本での発表から WebSphere に関わる。
 当初は製品マーケティング、その後ビジネスパートナー様向け技術営業に携わり、2010年に日本アイ・ビー・エム システムズ・エンジニアリング株式会社 (ISE) へ出向。
@@ -134,18 +134,21 @@ link:https://www.linkedin.com/in/atsushi-kurokawa/?originalSubdomain=jp[黒川�
 2002年に日本IBMに入社し、WASやRationalの技術営業として多くのお客様への提案、コンサルティング、またデリバリー部門でシステム開発に携わりました。2024年からLibertyを担当することになり、軽量さとゼロマイグレーションに感動して、お客様にマイグレーションを勧めています。link:https://qiita.com/blariver/items/f13e48aa91020e050631[WebSphereの歴史を振り返る (2024年版)]の記事を執筆しました。
 専門領域はDevOps(特に開発領域）です。中小企業診断士。趣味はサックスです。
 
-link:https://github.com/kaori-asa[浅田かおりさん]
+link:https://www.linkedin.com/in/kaori-asada-680355142/[浅田かおりさん]
 
-（現在休暇中のため、こちらの紹介文は、高宮が代筆させていただきました）浅田さんは、日本のOpenLibertyブログチームに所属されてないにもかかわらず、ブログ立ち上げ当初に飛び入りで多数の翻訳を手掛けてくださいました。
+浅田さんは、日本のOpenLibertyブログチームに所属されてないにもかかわらず、ブログ立ち上げ当初に飛び入りで多数の翻訳を手掛けてくださいました。
 そのおかげで、「誰でも貢献できるオープンソースの素晴らしさ」を実感することができました。浅田さんのご協力がなければブログの初期段階を乗り越えることは難しかったと思います。
+（浅田さんは休暇中のため、こちらの紹介文は、高宮が代筆させていただきました）
 
-link:https://github.com/takakiyo[田中 孝清さん]
+link:https://www.linkedin.com/in/takakiyo[田中 孝清さん]
 
-（現在休暇中のため、こちらの紹介文は、高宮が代筆させていただきました）田中さんは、日本IBMで，WebSphere Application Serverを中心としたテクニカルセールスを20年以上担当しています。Java言語，エンタープライズJava技術を中心に，各種コミュニティなどでの講演なども多数行っています。
+田中さんは、日本IBMで，WebSphere Application Serverを中心としたテクニカルセールスを20年以上担当しています。Java言語，エンタープライズJava技術を中心に，各種コミュニティなどでの講演なども多数行っています。
 
 田中さんの、第一回のブログ記事　link:https://openliberty.io/ja/blog/2022/09/01/openliberty-guides-in-japanese.html[Open Libertyのガイドを使ってクラウドネイティブのJavaアプリケーション開発とKubernetes環境へのデプロイメントについて学ぼう]
-は、ランキングでも常にトップ１０の人気記事です。月々のブログ記事翻訳も始められて、このブログの立役者的な存在です。Open LibertyとWebSphere Application Serverへの情熱は、
-link:https://qiita.com/TTakakiyo[Qiita技術記事執筆一覧]でも見ていただけます。
+は、ランキングでも常にトップ１０の人気記事です。月々のブログ記事の翻訳も始められて、このブログの立役者的な存在です。
+
+田中さんのOpen Libertyへの情熱は、
+link:https://qiita.com/TTakakiyo[Qiita技術記事執筆一覧]でも見ていただけます。（田中さんは、休暇中のため、こちらの紹介文は、高宮が代筆させていただきました）
 
 [#backend]
 == ブログを支えるチーム

--- a/posts/ja/2024-12-16-jblog-two-year-celebration.adoc
+++ b/posts/ja/2024-12-16-jblog-two-year-celebration.adoc
@@ -29,7 +29,7 @@ additional_authors:
 ---
 
 = OpenLibertyの日本語ブログが2周年を迎えました
-高宮　裕子 <https://github.com/una-tapa>
+高宮  裕子 <https://github.com/una-tapa>
 
 :imagesdir: /
 :url-prefix:

--- a/posts/ja/2024-12-16-jblog-two-year-celebration.adoc
+++ b/posts/ja/2024-12-16-jblog-two-year-celebration.adoc
@@ -11,6 +11,9 @@ blog_description: Open Libertyの日本語ブログが2022年にスタートし�
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
 additional_authors:
+- name: 高宮　裕子
+  github: https://github.com/una-tapa
+  image: https://avatars.githubusercontent.com/una-tapa
 - name: 田中 孝清
   github: https://github.com/takakiyo
   image: https://avatars.githubusercontent.com/takakiyo
@@ -29,7 +32,7 @@ additional_authors:
 ---
 
 = OpenLibertyの日本語ブログが2周年を迎えました
-高宮　裕子 <https://github.com/una-tapa>
+Hiroko Takamiya <https://github.com/una-tapa>
 
 :imagesdir: /
 :url-prefix:

--- a/posts/ja/2024-12-16-jblog-two-year-celebration.adoc
+++ b/posts/ja/2024-12-16-jblog-two-year-celebration.adoc
@@ -1,0 +1,215 @@
+---
+layout: post
+title: OpenLibertyの日本語ブログが2周年を迎えました
+# Do NOT change the categories section
+categories: blog
+author_picture: https://avatars3.githubusercontent.com/dmuelle
+author_github: https://github.com/dmuelle
+seo-title: OpenLibertyの日本語ブログが2周年を迎えました
+seo-description: Open Libertyの日本語ブログが2022年にスタートしてから2周年を迎えました。これまでの人気記事ランキングと、貢献してくれたコントリビューターを紹介します。
+blog_description: Open Libertyの日本語ブログが2022年にスタートしてから2周年を迎えました。これまでの人気記事ランキングと、貢献してくれたコントリビューターを紹介します。
+open-graph-image: https://openliberty.io/img/twitter_card.jpg
+open-graph-image-alt: Open Liberty Logo
+additional_authors: 
+- name: 田中 孝清 
+  github: https://github.com/takakiyo
+  image: https://avatars.githubusercontent.com/takakiyo
+- name: 馬場 剛 
+  github: https://github.com/babatch
+  image: https://avatars.githubusercontent.com/babatch
+- name: 浅田　かおり 
+  github: https://github.com/kaori-asa
+  image: https://avatars.githubusercontent.com/kaori-asa
+- name: 黒川　敦 
+  github: https://github.com/akurokawa
+  image: https://avatars.githubusercontent.com/akurokawa
+- name: 西尾実優香
+  github: https://github.com/MiyukaNishio
+  image: https://avatars.githubusercontent.com/MiyukaNishio
+---
+
+= OpenLibertyの日本語ブログが2周年を迎えました
+高宮　裕子 <https://github.com/unatapa>
+:imagesdir: /
+:url-prefix:
+:url-about: /
+//Blank line here is necessary before starting the body of the post.
+
+2022年にスタートした当ブログは、このたび2周年を迎えました！これもひとえに、読者の皆さま、そして素晴らしいContributorの皆さまのおかげです。本当にありがとうございます。
+
+当ブログでは、これまで日本語ユーザーにとって興味を持っていただけそうな有益な情報をお届けしてきました。この節目に、今まででアクセス数が多かった記事のランキングと、日本語ブログを支えてくださっているContributorの方々をご紹介したいと思います。
+
+* <<#ranking, 人気記事ランキング>>
+
+* <<#contributors, コントリビューターのご紹介>>
+
+* <<#backend, ブログを支えるチーム>>
+
+* <<#runs, 知識を力にLibertyを体験しよう！>>
+
+[#ranking]
+
+== 人気記事ランキング
+
+Open Libertyの日本語ブログでは、最新リリースに関する技術的な詳細や新機能の紹介が多くの読者から注目を集めています。特に、**「Open Liberty 23.0.0.2でのデータベース接続のテストとサーバー停止タイムアウトの設定」や「Open Liberty 23.0.0.9におけるSpring Boot 3.0のサポートと新しいセキュリティ機能」**など、具体的な設定方法や新たなサポート内容を詳しく解説した記事が人気です。
+
+また、**「Open Libertyのガイドを使ってクラウドネイティブのJavaアプリケーション開発とKubernetes環境へのデプロイメントについて学ぼう」**のように、実践的なガイドを提供する記事も多くの関心を集めています。これらの記事は、開発者が最新の技術やツールを効果的に活用するための貴重な情報源となっています。
+
+全体として、Open Libertyの日本語ブログは、リリース情報や技術ガイドを通じて、開発者コミュニティにとって重要なリソースとなっており、今後も多くの読者からの期待が寄せられています。
+
+=== 過去3か月の人気記事
+
+第1位：link:https://openliberty.io/ja/blog/2023/03/26/23.0.0.2.html[Open Liberty 23.0.0.2でのデータベース接続のテストとサーバー停止タイムアウトの設定]
+
+第2位：link:https://openliberty.io/ja/blog/2023/04/04/23.0.0.3.html[Open Liberty 23.0.0.3では、Jakarta EE 10, MicroProfile 6, および Java SE 20 のサポートが追加されました]
+
+第3位：link:https://openliberty.io/ja/blog/2024/06/18/24.0.0.6.html[24.0.0.6 での Spring Boot 3.x の起動高速化]
+
+第4位：link:https://openliberty.io/ja/blog/2023/10/17/23.0.0.10.html[Open Liberty 23.0.0.10でJava 21をサポート]
+
+第5位：link:https://openliberty.io/ja/blog/2024/03/26/24.0.0.3.html[24.0.0.3におけるデフォルトの冗長ガベージコレクションとOpenID Connectのバックチャネルログアウトのサポート]
+
+第6位：link:https://openliberty.io/ja/blog/2022/09/01/openliberty-guides-in-japanese.html[Open Libertyのガイドを使ってクラウドネイティブのJavaアプリケーション開発とKubernetes環境へのデプロイメントについて学ぼう]
+
+第7位：link:https://openliberty.io/ja/blog/2023/09/19/23.0.0.9.html[Open Liberty 23.0.0.9におけるSpring Boot 3.0のサポートと新しいセキュリティ機能]
+
+第8位：link:https://openliberty.io/ja/blog/2023/01/30/22.0.0.11.html[Open Liberty 22.0.0.11 での Java SE 19 および分散セキュリティー・キャッシュのサポート]
+
+第9位：link:https://openliberty.io/ja/blog/2023/05/02/23.0.0.4.html[Open Liberty 23.0.0.4では、ARM64アーキテクチャのコンテナ・イメージが利用可能になりました]
+
+第10位：link:https://openliberty.io/ja/blog/2023/12/12/23.0.0.12.html[Open Liberty 23.0.0.12におけるMicroProfile 6.1サポート, Liberty Toolsアップデート, 他]
+
+=== 過去1年の人気記事
+
+第1位：link:https://openliberty.io/ja/blog/2023/03/26/23.0.0.2.html[Open Liberty 23.0.0.2でのデータベース接続のテストとサーバー停止タイムアウトの設定]
+
+第2位：link:https://openliberty.io/ja/blog/2023/01/30/22.0.0.11.html[Open Liberty 22.0.0.11 での Java SE 19 および分散セキュリティー・キャッシュのサポート]
+
+第3位：link:https://openliberty.io/ja/blog/2023/09/19/23.0.0.9.html[Open Liberty 23.0.0.9におけるSpring Boot 3.0のサポートと新しいセキュリティ機能]
+
+第4位：link:https://openliberty.io/ja/blog/2022/09/01/openliberty-guides-in-japanese.html[Open Libertyのガイドを使ってクラウドネイティブのJavaアプリケーション開発とKubernetes環境へのデプロイメントについて学ぼう]
+
+第5位：link:https://openliberty.io/ja/blog/2023/05/02/23.0.0.4.html[Open Liberty 23.0.0.4では、ARM64アーキテクチャのコンテナ・イメージが利用可能になりました]
+
+第6位：link:https://openliberty.io/ja/blog/2023/10/17/23.0.0.10.html[Open Liberty 23.0.0.10でJava 21をサポート]
+
+第7位：link:https://openliberty.io/ja/blog/2023/01/31/22.0.0.12.html[Open Liberty 22.0.0.12における脆弱性と主なバグの修正]
+
+第8位：link:https://openliberty.io/ja/blog/2024/03/26/24.0.0.3.html[24.0.0.3におけるデフォルトの冗長ガベージコレクションとOpenID Connectのバックチャネルログアウトのサポート]
+
+第9位：link:https://openliberty.io/ja/blog/2023/04/04/23.0.0.3.html[Open Liberty 23.0.0.3では、Jakarta EE 10, MicroProfile 6, および Java SE 20 のサポートが追加されました]
+
+第10位：link:https://openliberty.io/ja/blog/2023/05/30/23.0.0.5.html[Open Liberty 23.0.0.5でMicroProfile 6とJakarta EE 10のガイドを更新]
+
+
+
+[#contributors]
+== コントリビューターのご紹介
+
+翻訳記事や技術情報を提供してくれているコントリビューターのみなさんから、一言いただいてきました。
+
+link:https://github.com/MiyukaNishio[西尾実優香さん]
+
+こんにちは、IBMに入社して2年目の西尾実優香です。現在はWebSphere Libertyのテクニカルセールスとして、プリセールス活動やコミュニティ運営に携わっています。
+IBMに入社前は会計学を専門としていたため、Java開発の経験はほとんどありませんでしたが、上司からスキルアップの一環としてOpen Libertyのブログ翻訳に参加する機会をいただきました。
+この経験を通じてLibertyの新機能を学び、また技術者としてのスキルを身につけることができています。
+まだまだ学ぶことが多いですが、今後も技術者として成長し、Open Libertyプロジェクトに貢献できるよう努力していきます。
+
+
+link:https://github.com/babatch[馬場 剛さん]
+
+1998年に日本アイ・ビー・エム株式会社 (IBMJ) へ入社後、同年末の WebSphere Application Server V1.1 の日本での発表から WebSphere に関わる。
+当初は製品マーケティング、その後ビジネスパートナー様向け技術営業に携わり、2010年に日本アイ・ビー・エム システムズ・エンジニアリング株式会社 (ISE) へ出向。
+ISE では主にプロジェクト・デリバリーを経験し、2022年より IBMJ へ帰任して App Modernization (WebSphere 含む)  技術営業。
+
+上の人気記事ランキングがとても興味深いです。
+アプリケーション・サーバーを動かせるようになったら、次はまずデータベースと接続してアプリケーションを作りたいのはいつの時代も変わらないようですね。
+Java / Jakarta EE, Java SE, MicroProfile の新バージョン対応のアナウンスも人気です。
+そしてやはり Spring 勢強し! ですね。
+ARM64 コンテナの記事が人気なのは、やはり Apple Silicon 搭載の新しい Mac で開発作業される方が増えてきているためでしょうか。私もその一人だったりします。 
+これからも進化していく Open Liberty / WebSphere Liberty をよろしくお願いいたします!
+
+link:https://www.linkedin.com/in/atsushi-kurokawa/?originalSubdomain=jp[黒川敦さん]
+
+2002年に日本IBMに入社し、WASやRationalの技術営業として多くのお客様への提案、コンサルティング、またデリバリー部門でシステム開発に携わりました。2024年からLibertyを担当することになり、軽量さとゼロマイグレーションに感動して、お客様にマイグレーションを勧めています。link:https://qiita.com/blariver/items/f13e48aa91020e050631[WebSphereの歴史を振り返る (2024年版)]の記事を執筆しました。
+専門領域はDevOps(特に開発領域）です。中小企業診断士。趣味はサックスです。
+
+link:https://github.com/kaori-asa[浅田かおりさん]
+
+（現在休暇中のため、こちらの紹介文は、高宮が代筆させていただきました）浅田さんは、日本のOpenLibertyブログチームに所属されてないにもかかわらず、ブログ立ち上げ当初に飛び入りで多数の翻訳を手掛けてくださいました。
+そのおかげで、「誰でも貢献できるオープンソースの素晴らしさ」を実感することができました。浅田さんのご協力がなければブログの初期段階を乗り越えることは難しかったと思います。
+
+link:https://github.com/takakiyo[田中 孝清さん]
+
+（現在休暇中のため、こちらの紹介文は、高宮が代筆させていただきました）田中さんは、日本IBMで，WebSphere Application Serverを中心としたテクニカルセールスを20年以上担当しています。Java言語，エンタープライズJava技術を中心に，各種コミュニティなどでの講演なども多数行っています。
+
+田中さんの、第一回のブログ記事　link:https://openliberty.io/ja/blog/2022/09/01/openliberty-guides-in-japanese.html[Open Libertyのガイドを使ってクラウドネイティブのJavaアプリケーション開発とKubernetes環境へのデプロイメントについて学ぼう]
+は、ランキングでも常にトップ１０の人気記事です。月々のブログ記事翻訳も始められて、このブログの立役者的な存在です。Open LibertyとWebSphere Application Serverへの情熱は、
+link:https://qiita.com/TTakakiyo[Qiita技術記事執筆一覧]でも見ていただけます。
+
+[#backend]
+== ブログを支えるチーム
+
+この記事を執筆している高宮です。米ノースカロライナのIBMのラボで働いています。日本のユーザーの皆さまから「Libertyに関する技術的な記事を日本語で読めたら嬉しい」という声をいただき、月に一度のLibertyブログを日本語化しようというアイデアが生まれました。
+
+その実現に向けて、多言語対応の仕組みをコツコツと追加してくれたり、技術や時間を割いてブログをサポートしてくれたり、さらに、日本のユーザーの重要性を熱意を持って伝えてくれたメンバーがいます。この場を借りて、そんなブログを支えるチームをご紹介させていただきます。
+
+link:https://openliberty.io/blog/2021/12/10/DavidMueller_MeetTheTeam.html[David Mueller]:
+Davidはドキュメンテーションチームのリーダーで、記事に関することはどんな相談にも応じてくれる頼れる存在です。
+
+link:https://github.com/kinueng[Kin Ueng], link:https://github.com/steven1046[Steven Zvonek], link:https://github.com/OpenLiberty/blogs/pulls/natalie-bernhard[Natalie Bernhard] :
+Kin, Steven, Natalieは、ブログ投稿の仕組みや多言語対応の相互リンクを構築してくれた立役者たちです。また、日本語のバナーやボタンも作成してくれました。
+
+link:https://github.com/yeekangc[Yee-Kang Chang], link:https://github.com/GraceJansen[Grace Jansen], link:https://github.com/Emily-Jiang[Emily Jiang]
+YKはデベロッパー・アドボカシーのアーキテクトとして、EmilyとGraceはJavaチャンピオンとして、それぞれの役割を通じてワールドワイドのコミュニティ活動の一環として、OpenLibertyの日本語ブログを支えてくれています。
+
+[#run]
+== 知識を力にLibertyを体験しよう！
+
+Libertyの日本語ブログ記事を参考に、ぜひLibertyを体験してみてください。Libertyは、さまざまな開発スタイルに柔軟に対応しています。
+
+また、OpenLibertyでは、読者の皆さまからのコントリビューションも大歓迎です。「こんなことを試してみたよ！」とシェアしたいトピックがありましたら、ぜひブログのコントリビューターまで声をかけてください。
+
+それでは引き続きOpenLibertyをよろしくお願いいたします！
+
+link:{url-prefix}/guides/maven-intro.html[Maven]での開発は、`pom.xml` ファイルに以下を含めます。
+
+[source,xml]
+----
+<plugin>
+    <groupId>io.openliberty.tools</groupId>
+    <artifactId>liberty-maven-plugin</artifactId>
+    <version>3.10.3</version>
+</plugin>
+----
+
+link:{url-prefix}/guides/gradle-intro.html[Gradle] をお使いの場合は、`build.gradle` ファイルに次の内容を含めます。
+
+[source,gradle]
+----
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.8.3'
+    }
+}
+apply plugin: 'liberty'
+----
+
+または、link:{url-prefix}/docs/latest/container-images.html[コンテナ イメージ] を使用している場合は、下記のようにイメージを入手できます。
+
+[source]
+----
+FROM icr.io/appcafe/open-liberty
+----
+
+link:{url-prefix}/start/[ダウンロード・ページ]も併せてご覧ください。
+
+link:https://plugins.jetbrains.com/plugin/14856-liberty-tools[IntelliJ IDEA]、link:https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext[Visual Studio Code]、または link:https://marketplace.eclipse.org/content/liberty-tools[Eclipse IDE]で開発されている場合は、オープンソースの link:https://openliberty.io/docs/latest/develop-liberty-tools.html[Liberty 開発者ツール] を活用して、IDE 内から効果的な開発、テスト、デバッグ、アプリケーション管理をお勧めします。
+
+[link=https://stackoverflow.com/tags/open-liberty]
+image::img/blog/blog_btn_stack_ja.svg[Ask a question on Stack Overflow, align="center"]
+
+

--- a/posts/ja/2024-12-16-jblog-two-year-celebration.adoc
+++ b/posts/ja/2024-12-16-jblog-two-year-celebration.adoc
@@ -10,17 +10,17 @@ seo-description: Open Libertyの日本語ブログが2022年にスタートし�
 blog_description: Open Libertyの日本語ブログが2022年にスタートしてから2周年を迎えました。これまでの人気記事ランキングと、貢献してくれたコントリビューターを紹介します。
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
-additional_authors: 
-- name: 田中 孝清 
+additional_authors:
+- name: 田中 孝清
   github: https://github.com/takakiyo
   image: https://avatars.githubusercontent.com/takakiyo
-- name: 馬場 剛 
+- name: 馬場 剛
   github: https://github.com/babatch
   image: https://avatars.githubusercontent.com/babatch
-- name: 浅田　かおり 
+- name: 浅田　かおり
   github: https://github.com/kaori-asa
   image: https://avatars.githubusercontent.com/kaori-asa
-- name: 黒川　敦 
+- name: 黒川　敦
   github: https://github.com/akurokawa
   image: https://avatars.githubusercontent.com/akurokawa
 - name: 西尾実優香
@@ -30,6 +30,7 @@ additional_authors:
 
 = OpenLibertyの日本語ブログが2周年を迎えました
 高宮　裕子 <https://github.com/una-tapa>
+
 :imagesdir: /
 :url-prefix:
 :url-about: /
@@ -126,7 +127,7 @@ ISE では主にプロジェクト・デリバリーを経験し、2022年より
 アプリケーション・サーバーを動かせるようになったら、次はまずデータベースと接続してアプリケーションを作りたいのはいつの時代も変わらないようですね。
 Java / Jakarta EE, Java SE, MicroProfile の新バージョン対応のアナウンスも人気です。
 そしてやはり Spring 勢強し! ですね。
-ARM64 コンテナの記事が人気なのは、やはり Apple Silicon 搭載の新しい Mac で開発作業される方が増えてきているためでしょうか。私もその一人だったりします。 
+ARM64 コンテナの記事が人気なのは、やはり Apple Silicon 搭載の新しい Mac で開発作業される方が増えてきているためでしょうか。私もその一人だったりします。
 これからも進化していく Open Liberty / WebSphere Liberty をよろしくお願いいたします!
 
 link:https://www.linkedin.com/in/atsushi-kurokawa/?originalSubdomain=jp[黒川敦さん]
@@ -214,5 +215,3 @@ link:https://plugins.jetbrains.com/plugin/14856-liberty-tools[IntelliJ IDEA]、l
 
 [link=https://stackoverflow.com/tags/open-liberty]
 image::img/blog/blog_btn_stack_ja.svg[Ask a question on Stack Overflow, align="center"]
-
-

--- a/posts/ja/2024-12-16-jblog-two-year-celebration.adoc
+++ b/posts/ja/2024-12-16-jblog-two-year-celebration.adoc
@@ -29,7 +29,7 @@ additional_authors:
 ---
 
 = OpenLibertyの日本語ブログが2周年を迎えました
-高宮  裕子 <https://github.com/una-tapa>
+高宮　裕子 <https://github.com/una-tapa>
 
 :imagesdir: /
 :url-prefix:


### PR DESCRIPTION
Hi, @dmuelle 

This article marks the second anniversary of the Japanese Open Liberty blog. Unfortunately, we encountered an issue where the link https://github.com/una-tapa could not be removed after being merged into the draft. We would appreciate assistance in removing this, as well as the word "and" which we find to be extraneous.

![image](https://github.com/user-attachments/assets/2995abfe-b062-4bae-9a29-e498d5f4ec9d)

Apart from the above, the draft has been reviewed and approved by everyone involved. We are hoping it to be published by December 20th to coincide with our participation in the WebSphere Advent Calendar event over there. 

Thank you in advance! 
