### PR TITLE
Update references to Release Architect

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-blog-post.md
+++ b/.github/ISSUE_TEMPLATE/release-blog-post.md
@@ -27,11 +27,11 @@ Follow the instructions in the README and the template file to complete the foll
 - [ ] Create a draft blog post using the [GA release blog post template](https://github.com/OpenLiberty/blogs/blob/prod/templates/ga-release-post.adoc) or the [beta release blog post template](https://github.com/OpenLiberty/blogs/blob/prod/templates/beta-release-post.adoc). Build the draft blog post on the draft website according to the [blog post instructions](https://github.com/OpenLiberty/blogs/blob/prod/README.md).
 - [ ] When you've compiled the whole blog and checked that it makes sense to the best of your knowledge, create a PR from your feature branch to the `staging` branch (as described in the [blog post instructions](https://github.com/OpenLiberty/blogs/blob/prod/README.md)).
 - [ ] Get the draft post reviewed by all the people who contributed the content to the blog post.
-- [ ] Then, when they're all happy, ask @mbroz2 to review it.
-- [ ] Agree with @mbroz2 which feature will lead this blog post, then write a title, slug, summary first paragraph, and SEO front matter appropriately.
+- [ ] Then, when they're all happy, ask the [Release Architect](https://github.com/orgs/OpenLiberty/teams/release-architect) to review it.
+- [ ] Agree with the [Release Architect](https://github.com/orgs/OpenLiberty/teams/release-architect) which feature will lead this blog post, then write a title, slug, summary first paragraph, and SEO front matter appropriately.
 - [ ] Add relevant tags to the post in the `staging` branch (see [the blog post instructions](https://github.com/OpenLiberty/blogs#editors-editing-and-publishing-a-post)).
-- [ ] Get the post approved by @mbroz2.
-- [ ] On release day (usually Tuesday for the GA release post and Thursday for the beta release post), @mbroz2 will publish the post.
+- [ ] Get the post approved by the [Release Architect](https://github.com/orgs/OpenLiberty/teams/release-architect).
+- [ ] On release day (usually Tuesday for the GA release post and Thursday for the beta release post), the [Release Architect](https://github.com/orgs/OpenLiberty/teams/release-architect) will publish the post.
 
 ## All done?
 

--- a/templates/ga-release-post.adoc
+++ b/templates/ga-release-post.adoc
@@ -243,7 +243,7 @@ For more details, check the LINK[LINK_DESCRIPTION].
 |===
 // // // // // // // //
 // In the preceding section:
-// If there were any CVEs addressed in this release, fill out the table.  For the information, reference https://github.com/OpenLiberty/docs/blob/draft/modules/ROOT/pages/security-vulnerabilities.adoc.  If it has not been updated for this release, reach out to Kristen Clarke or Michal Broz.
+// If there were any CVEs addressed in this release, fill out the table.  For the information, reference https://github.com/OpenLiberty/docs/blob/draft/modules/ROOT/pages/security-vulnerabilities.adoc.  If it has not been updated for this release, reach out to Kristen Clarke or the Release Architect (https://github.com/orgs/OpenLiberty/teams/release-architect).
 // Note: When linking to features, use the 
 // `link:{url-prefix}/docs/latest/reference/feature/someFeature-1.0.html[Some Feature 1.0]` format and 
 // NOT what security-vulnerabilities.adoc does (feature:someFeature-1.0[])
@@ -262,7 +262,7 @@ We’ve spent some time fixing bugs. The following sections describe just some o
 
 // // // // // // // //
 // In the preceding section:
-// For this section ask either Michal Broz or Tom Evans or the #openliberty-release-blog channel for Notable bug fixes in this release.
+// For this section ask either the Release Architect (https://github.com/orgs/OpenLiberty/teams/release-architect) or Tom Evans or the #openliberty-release-blog channel for Notable bug fixes in this release.
 // Present them as a list in the order as provided, linking to the issue and providing a short description of the bug and the resolution.
 // If the issue on Github is missing any information, leave a comment in the issue along the lines of:
 // "@[issue_owner(s)] please update the description of this `release bug` using the [bug report template](https://github.com/OpenLiberty/open-liberty/issues/new?assignees=&labels=release+bug&template=bug_report.md&title=)" 
@@ -273,7 +273,7 @@ We’ve spent some time fixing bugs. The following sections describe just some o
 
 // // // // // // // //
 // If there were updates to guides since last release, keep the following, otherwise remove section.
-// Check with Gilbert Kwan, otherwise Michal Broz or YK Chang
+// Check with Gilbert Kwan, otherwise the Release Architect (https://github.com/orgs/OpenLiberty/teams/release-architect) or YK Chang
 // // // // // // // //
 [#guides]
 == New and updated guides since the previous release


### PR DESCRIPTION
Update references from Michal to the Release Architect group (https://github.com/orgs/OpenLiberty/teams/release-architect).