### PR TITLE
replace gcr.io with docker.io

### DIFF
--- a/posts/2022-04-01-cloud-native-liberty-buildpack.adoc
+++ b/posts/2022-04-01-cloud-native-liberty-buildpack.adoc
@@ -112,10 +112,10 @@ Create `project.toml` file in the finish directory with the following content:
     value ="target/*.[ejw]ar src/main/liberty/config/*"
 
 [[build.buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/eclipse-openj9"
+  uri = "docker://docker.io/paketobuildpacks/eclipse-openj9"
 
 [[build.buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/java"
+  uri = "docker://docker.io/paketobuildpacks/java"
 ----
 Build the application on Liberty with IBM Semeru OpenJ9 and required Liberty features:
 [source]


### PR DESCRIPTION
Paketo buildpacks will stop publishing images to gcr.io.  Updating instructions to use docker.io.  