### PR TITLE
replace gcr.io with docker.io

### DIFF
--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -52,10 +52,10 @@ For example, your project descriptor might contain the following content to use 
     value = "jsonb-2.0 mpconfig-3.0 mpmetrics-4.0 restfulws-3.0 jsonp-2.0 cdi-3.0"     
     
 [[build.buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/eclipse-openj9"
+  uri = "docker://docker.io/paketobuildpacks/eclipse-openj9"
   
 [[build.buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/java"
+  uri = "docker://docker.io/paketobuildpacks/java"
 ```
 
 == Build and push a container image with Azure


### PR DESCRIPTION
paketo will stop publishing to gcr.io so need to update blog to use docker.io.