### PR TITLE
replace gcr.io with docker.io

### DIFF
--- a/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
+++ b/posts/2023-02-17-using-liberty-buildpack-on-azure-and-google-cloud.adoc
@@ -52,10 +52,10 @@ For example, your project descriptor might contain the following content to use 
     value = "jsonb-2.0 mpconfig-3.0 mpmetrics-4.0 restfulws-3.0 jsonp-2.0 cdi-3.0"     
     
 [[build.buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/eclipse-openj9"
+  uri = "docker://docker.io/paketobuildpacks/eclipse-openj9"
   
 [[build.buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/java"
+  uri = "docker://docker.io/paketobuildpacks/java"
 ```
 
 == Build and push a container image with Azure


### PR DESCRIPTION
The Paketo community will stop publishing to gcr.io so I am updating this blog post to use docker.io instead.

https://blogs-draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/blog/2023/02/17/using-liberty-buildpack-on-azure-and-google-cloud.html

![image](https://github.com/user-attachments/assets/4bd80137-8014-42ed-9db9-be188383bdfa)
