### PR TITLE
Fix invalid header for 25.0.0.3 Japanese translation. 

### DIFF
--- a/posts/ja/2025-03-25-25.0.0.3.adoc
+++ b/posts/ja/2025-03-25-25.0.0.3.adoc
@@ -1,4 +1,4 @@
-v---
+---
 layout: post
 title: "25.0.0.3におけるFIPS 140-3のサポートとlibrary設定の簡素化"
 # Do NOT change the categories section


### PR DESCRIPTION
Removed an extra character at the beginning. 