### PR TITLE
Removing embedded links from blogs

### DIFF
--- a/posts/2019-09-05-12-factor-microprofile-kubernetes.adoc
+++ b/posts/2019-09-05-12-factor-microprofile-kubernetes.adoc
@@ -7,7 +7,6 @@ seo-title: Twelve Factor App best practices in microservices with MicroProfile a
 seo-description: Twelve Factor App, a widely adopted methodology, defines best practices for creating microservices. MicroProfile and Kubernetes can be used to implement the 12 factors, clarifying the boundary between application and infrastructure, minimising divergence between development and production, and enabling microservices to scale easily.
 blog_description:  Twelve Factor App, a widely adopted methodology, defines best practices for creating microservices. MicroProfile and Kubernetes can be used to implement the 12 factors, clarifying the boundary between application and infrastructure, minimising divergence between development and production, and enabling microservices to scale easily.
 ---
-
 = Twelve Factor App best practices in microservices with MicroProfile and Kubernetes
 Emily Jiang <https://github.com/Emily-Jiang>
 :imagesdir: /
@@ -16,11 +15,9 @@ Emily Jiang <https://github.com/Emily-Jiang>
  
 As a microservices developer, you might be wondering whether there are best practices.  Yes, there are: 12 Factor App is a widely adopted methodology for link:/docs/ref/general/#cloud_native_microservices.html[creating microservices]. link:https://www.12factor.net[12 Factor App] clarifies the boundary between application and infrastructure, minimises divergence between development and production, and enables your microservices to scale up or down without significant changes to tooling, architecture, or development practices. The 12 Factor App methodology defines the theory but there is no known implementation.
 
-At Devoxx UK earlier this year, I demonstrated how to create two 12 factor microservices (using link:/docs/intro/microprofile.html[Eclipse MicroProfile] and Kubernetes) and deploy them to Minikube. If you want to watch the whole talk, here it is:
+At Devoxx UK earlier this year, I demonstrated how to create two 12 factor microservices (using link:/docs/intro/microprofile.html[Eclipse MicroProfile] and Kubernetes) and deploy them to Minikube. 
 
-++++
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Ov3BbGl2iyQ?start=273" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-++++
+Checkout the YouTube video if you want to link:"https://www.youtube.com/watch?v=Ov3BbGl2iyQ?start=273"[watch the whole talk].
 
 Here is a quick overview of how you can use MicroProfile and Kubernetes to implement the 12 factors when creating microservices:
  

--- a/posts/2019-10-22-liberty-dev-mode.adoc
+++ b/posts/2019-10-22-liberty-dev-mode.adoc
@@ -16,11 +16,7 @@ Eric Lau <https://github.com/ericglau>
 
 Open Liberty development mode, or dev mode, allows you to develop applications with any text editor or IDE by providing hot reload and deployment, on demand testing, and debugger support.  Your code is automatically compiled and deployed to your running server, making it easy to iterate on your changes. You can run tests on demand or even automatically so that you can get immediate feedback on your changes. You can also attach a debugger at any time to debug your running application.
 
-For a quick demo of what you can do with dev mode, check out the following video:
-
-++++
-<iframe width="560" height="315" src="https://www.youtube.com/embed/eetnJrhVOMM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-++++
+Check out the YouTube video for a link:"https://www.youtube.com/watch?v=eetnJrhVOMM"[quick demo of what you can do with dev mode]
 
 You can also follow the steps in the https://github.com/OpenLiberty/demo-devmode[demo-devmode] project used in the above video to try it out yourself.
 

--- a/posts/2020-09-03-open-liberty-tools-intellij.adoc
+++ b/posts/2020-09-03-open-liberty-tools-intellij.adoc
@@ -24,10 +24,7 @@ image::img/blog/intellij-dev-dashboard.png[Liberty Dev Dashboard in IntelliJ IDE
 
 In previous blogs, we have shown you how Open Liberty dev mode can be https://openliberty.io/blog/2019/10/22/liberty-dev-mode.html[run from a command line with Maven] and with https://openliberty.io/blog/2020/03/11/gradle-dev-mode-open-liberty.html[Gradle].  In this blog post, you will see how the Open Liberty Tools extension improves the developer experience by conveniently displaying Open Liberty projects and dev mode interactions within IntelliJ.  
 
-Check out a demo of Open Liberty Tools for IntelliJ:
-++++
-<iframe width="560" height="315" src="https://www.youtube.com/embed/GIIhtdXwJ9A" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-++++
+Check out the YouTube video for a link:"https://www.youtube.com/watch?v=GIIhtdXwJ9A"[demo of Open Liberty Tools for IntelliJ]:
 
 == Installing the extension
 

--- a/posts/2021-01-20-open-liberty-devfile-stack.adoc
+++ b/posts/2021-01-20-open-liberty-devfile-stack.adoc
@@ -14,10 +14,7 @@ Adam Wisniewski <https://github.com/awisniew90>
 
 True-to-production development is critical when you create cloud-native applications, and what better way to develop those applications than directly in the cloud! The link:https://github.com/OpenLiberty/devfile-stack[Open Liberty devfile stack] allows you to do just that by providing a simple yet robust Open Liberty development experience directly in a Kubernetes or OpenShift cluster. The devfile stack does the heavy lifting by allowing you to focus on your code as if it were running right on your laptop.
 
-Check out a quick demo:
-++++
-<iframe width="560" height="315" align="center" src="https://www.youtube.com/embed/e_oIInKFtHw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-++++
+Check out the YouTube video for a link:"https://www.youtube.com/watch?v=e_oIInKFtHw"[quick demo]:
 
 == OpenShift Do
 

--- a/posts/2021-04-14-open-liberty-devfile-stack-minikube.adoc
+++ b/posts/2021-04-14-open-liberty-devfile-stack-minikube.adoc
@@ -14,10 +14,7 @@ Adam Wisniewski <https://github.com/awisniew90>
 
 With the Open Liberty devfile stack, you can develop new and existing cloud-native applications link:https://openliberty.io/blog/2021/01/20/open-liberty-devfile-stack.html[directly in an OpenShift cluster]. But what if you don't have access to a remote cluster? No problem! You can still get all of the benefits of stack development locally with Minikube.
 
-Check out a quick demo:
-++++
-<iframe width="560" height="315" align="center" src="https://www.youtube.com/embed/KFjVGPyL49Q" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-++++
+Check out the YouTube video for a link:"https://www.youtube.com/watch?v=KFjVGPyL49Q"[quick demo]:
 
 == Minikube
 

--- a/posts/2022-03-25-dev-mode-with-eclipse.adoc
+++ b/posts/2022-03-25-dev-mode-with-eclipse.adoc
@@ -20,11 +20,8 @@ The Eclipse integrated development environment (IDE) is one of the most popular 
 
 link:{url-prefix}/docs/latest/development-mode.html[Liberty dev mode] enables you to quickly and iteratively develop cloud-native Java applications with the latest Jakarta EE and MicroProfile technologies. Dev mode watches your project for file changes and provides hot reload and deployment, on demand testing, and debugger support. You can work with dev mode from anywhere, whether it's from a terminal with a text editor or your favorite IDE. https://marketplace.eclipse.org/content/ibm-liberty-developer-tools[Liberty Developer Tools] is an Eclipse plugin that provides helpful server configuration editor views. In the following sections, we detail the current best practices for using dev mode, and optionally Liberty Developer Tools, to develop your application within the Eclipse IDE.
 
-Check out a demo of working with Liberty dev mode in the Eclipse IDE:
+Check out the YouTube video for a link:"https://www.youtube.com/watch?v=613VBYdk6f8"[demo of working with Liberty dev mode in the Eclipse IDE]:
 
-++++
-<iframe width="560" height="315" src="https://www.youtube.com/embed/613VBYdk6f8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-++++
 
 == Working with dev mode in the Eclipse IDE with Liberty Developer Tools
 

--- a/posts/2022-08-01-liberty-tools-eclipse.adoc
+++ b/posts/2022-08-01-liberty-tools-eclipse.adoc
@@ -14,7 +14,7 @@ Adam Wisniewski <https://github.com/awisniew90>
 
 Liberty Tools for Eclipse provides a new experience for developing applications with Open Liberty. This early release supports editing Liberty `server.xml` configuration, developing MicroProfile applications, a Liberty Dashboard for organizing your projects, and Liberty dev mode functions, all from within your IDE. 
 
-Check out the youtube video for a link:"https://www.youtube.com/watch?v=_ucSs20sUVc"[demo]:
+Check out the YouTube video for a link:"https://www.youtube.com/watch?v=_ucSs20sUVc"[demo]:
 
 
 == Liberty Dashboard

--- a/posts/2022-08-01-liberty-tools-eclipse.adoc
+++ b/posts/2022-08-01-liberty-tools-eclipse.adoc
@@ -14,11 +14,8 @@ Adam Wisniewski <https://github.com/awisniew90>
 
 Liberty Tools for Eclipse provides a new experience for developing applications with Open Liberty. This early release supports editing Liberty `server.xml` configuration, developing MicroProfile applications, a Liberty Dashboard for organizing your projects, and Liberty dev mode functions, all from within your IDE. 
 
-Check out this quick video demo:
+Check out the youtube video for a link:"https://www.youtube.com/watch?v=_ucSs20sUVc"[demo]:
 
-++++
-<iframe width="560" height="315" align="center" src="https://www.youtube.com/embed/_ucSs20sUVc" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-++++
 
 == Liberty Dashboard
 

--- a/posts/2022-09-21-history-maker-projects.adoc
+++ b/posts/2022-09-21-history-maker-projects.adoc
@@ -41,9 +41,7 @@ One much-travelled Liberty conference demo was the link:https://github.com/WASde
 .Remote controlled car with embedded Arduino running Liberty.
 image::img/blog/crafters-liberty-car.jpeg[Remote controlled car with embedded Arduino running Liberty,width=50%,align="center"]
 
-Any conference attendee could connect and control the car from their own smartphone, demonstrating, among other things, the responsiveness of link:https://www.infoq.com/news/2013/06/ee7-websocket-support/[2013's Java EE 7 WebSocket technology]. Java EE, not then known for its small, lightweight footprint, ran easily on the limited hardware resources. Tom's Liberty Car project matured into a conference game where attendees could race multiple Liberty Cars around a large race-track. Tom talks through how it works:
-
-video::LnmjAUEhfX8[youtube]
+Any conference attendee could connect and control the car from their own smartphone, demonstrating, among other things, the responsiveness of link:https://www.infoq.com/news/2013/06/ee7-websocket-support/[2013's Java EE 7 WebSocket technology]. Java EE, not then known for its small, lightweight footprint, ran easily on the limited hardware resources. Tom's Liberty Car project matured into a conference game where attendees could race multiple Liberty Cars around a large race-track. Check out the link:https://www.youtube.com/watch?v=LnmjAUEhfX8[YouTube video] where Tom talks through how it works.
 
 == Wearable and throwable infrastructures
 
@@ -55,9 +53,7 @@ Queen of link:https://www.manning.com/books/enterprise-osgi-in-action[Enterprise
 .Holly presenting in her chef's hat at JFokus. Photo by Kate Stanley.
 image::img/blog/crafters-holly-hat-jfokus.jpg[Holly presenting in her chef's hat at JFokus,width=50%,align="center"]
 
-You can find out more from Holly as she talks about her wearable Java runtime:
-
-video::OE5SLt7UlJk[youtube]
+Check out the link:https://www.youtube.com/watch?v=OE5SLt7UlJk[YouTube video] where Holly talks about her wearable Java runtime.
 
 After a couple of years of sporting a chef's hat at Enterprise Java conferences, Holly went further with her Java runtime crafting and made link:https://www.infoq.com/presentations/arduino-app-server/[a cuddly throwable Java runtime]. This was an actual cuddly ball with LEDs and a Raspberry Pi embedded in it. She would throw the ball into the audience part-way through her talk and encourage them to chuck it around the room during her presentations.
 

--- a/posts/2023-02-14-liberty-tools-intellij-early-release.adoc
+++ b/posts/2023-02-14-liberty-tools-intellij-early-release.adoc
@@ -53,9 +53,7 @@ With the latest early release of Liberty Tools for IntelliJ IDEA, you can iterat
 
 Try it out today with IntelliJ IDEA 2022.2+, installable via the link:https://plugins.jetbrains.com/plugin/14856-liberty-tools/[Jetbrains marketplace].
 
-Check out the following video to see all the Liberty Tools for IntelliJ IDEA features:
-
-video::2T-ALsTGRY0[youtube, width="560", height="315"]
+Check out the link:https://www.youtube.com/watch?v=2T-ALsTGRY0[YouTube video] to see all the Liberty Tools for IntelliJ IDEA features.
 
 == What's New
 

--- a/posts/2023-03-08-liberty-tools-eclipse-deep-dive.adoc
+++ b/posts/2023-03-08-liberty-tools-eclipse-deep-dive.adoc
@@ -16,9 +16,7 @@ Liberty Tools for Eclipse IDE provides a simplified yet powerful development exp
 
 Try it out today by installing from the link:https://marketplace.eclipse.org/content/liberty-tools[Eclipse Marketplace].
 
-Check out the following video for a deep dive walk-through of Liberty Tools for Eclipse IDE:
-
-video::vfi0JsXZrgc[youtube, width="560", height="315", align="center"]
+Check out the link:https://www.youtube.com/watch?v=vfi0JsXZrgc[YouTube video] for a deep dive walk-through of Liberty Tools for Eclipse IDE.
 
 Let's dive in!
 

--- a/posts/2024-03-06-DevNexus24.adoc
+++ b/posts/2024-03-06-DevNexus24.adoc
@@ -143,8 +143,5 @@ As well as the numerous sessions during the conference and our dedicated Open Li
 This year, we’ll also have our exciting intergalactic booth challenge…
 link:https://www.youtube.com/watch?v=bURqsxP5gEY&t=139s[The Open Liberty Space Rover Challenge]. In this challenge, you’ll need to navigate the planets and get your rover safely to your destination in the stars. Take control of a spaceship and use hand signals to direct it's flight from planet to planet. Climb the rankings on your way to become top cadet in Star Academy. While you're with us, ask our developers about the underlying technologies they've used to create the demo, including OpenJ9, Jakarta EE, MicroProfile, and "the most flexible runtime in the cosmos", Open Liberty.
 
-video::bURqsxP5gEY[youtube, width="560", height="315", align="center"]
-
-
 == Summary
 We hope this guide helps you to plan your time at DevNexus. If you're interested in other sessions, check out the link:https://devnexus.com/schedule[full schedule] on the DevNexus link:https://devnexus.com/[conference website].

--- a/posts/2024-04-01-open-liberty-with-langchain4j-example.adoc
+++ b/posts/2024-04-01-open-liberty-with-langchain4j-example.adoc
@@ -38,9 +38,7 @@ In this post, we'll explore what LLMs are and how to use them in Java applicatio
 
 A language model is a model of natural language based on probabilities. They are able to generate probabilities of a series of words together. https://www.ibm.com/topics/large-language-models[Large language models (LLMs)] are simply language models that are categorized by their large size. They are trained on immense amounts of data, possibly billions of parameters, by using self-supervised and semi-supervised learning techniques. This training enables them to generate natural language and other types of content to perform a wide range of tasks.
 
-See the following introductory video for more information on LLMs, including what they are, how they work, and their business applications.
-
-video::5sLYAQS9sWQ[youtube, width="560", height="315", align="center"]
+Check out the link:https://www.youtube.com/watch?v=5sLYAQS9sWQ[introductory video] for more information on LLMs, including what they are, how they work, and their business applications.
 
 You can find LLMs in the service offerings of almost all of the major cloud service providers. For example, IBM offers models through its link:https://www.ibm.com/watsonx[watsonx] services, link:https://azure.microsoft.com/en-us/solutions/ai[Microsoft Azure] offers LLMs like Llama 2 and OpenAI GPT-4, and  link:https://aws.amazon.com/bedrock/[Amazon Bedrock] offers models from a range of AI companies.
 


### PR DESCRIPTION
Link to the issue [here](https://github.com/OpenLiberty/blogs/issues/4507)

Embedded links are flagged by IBM Compliance team told by @NottyCode 