### PR TITLE
Publish MCP Server blog post updates

### DIFF
--- a/blog_tags.json
+++ b/blog_tags.json
@@ -267,7 +267,8 @@
         },
         {
             "name": "beta",
-            "posts": ["25.0.0.12-beta", "25.0.0.11-beta", 
+            "posts": ["mcp-standalone-blog",
+                      "25.0.0.12-beta", "25.0.0.11-beta",
                       "25.0.0.10-beta","25.0.0.9-beta",
                       "25.0.0.7-beta", "25.0.0.6-beta", 
                       "25.0.0.4-beta", "25.0.0.3-beta",

--- a/posts/2025-10-23-mcp-standalone-blog.adoc
+++ b/posts/2025-10-23-mcp-standalone-blog.adoc
@@ -6,8 +6,8 @@ categories: blog
 author_picture: https://avatars3.githubusercontent.com/habiblawal1
 author_github: https://github.com/habiblawal1
 seo-title: Support for the Model Context Protocol within Open Liberty - OpenLiberty.io
-seo-description: Learn how to use the MCP Server feature within your Liberty application to allow your business logic to be utilized within an agentic AI workflow.
-blog_description: Learn how to use the MCP Server feature within your Liberty application to allow your business logic to be utilized within an agentic AI workflow.
+seo-description: Learn how to use the MCP Server beta feature within your Liberty application to allow your business logic to be utilized within an agentic AI workflow.
+blog_description: Learn how to use the MCP Server beta feature within your Liberty application to allow your business logic to be utilized within an agentic AI workflow.
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
 ---
@@ -21,7 +21,7 @@ Habib Lawal <https://github.com/habiblawal1>
 == What is MCP
 Model Context Protocol (MCP) is an open standard that enables AI applications to interact with and utilize external systems.
 
-The Liberty **MCP Server feature** allows developers to expose the business logic of their applications, making it discoverable, understandable, and usable by AI applications.
+The Liberty **MCP Server beta feature** allows developers to expose the business logic of their applications, making it discoverable, understandable, and usable by AI applications.
 
 
 == The Power of MCP

--- a/posts/2025-10-23-mcp-standalone-blog.adoc
+++ b/posts/2025-10-23-mcp-standalone-blog.adoc
@@ -31,8 +31,8 @@ Consider a scenario where your company provides weather forecasting services tha
 
 A more effective solution is to enable the AI to access current weather data through tools exposed by your Liberty application. This allows the AI to retrieve up-to-date forecast information whenever needed, ensuring responses are always based on the most current data available, without the need for AI model retraining.
 
-== How to Use the Liberty MCP Server Feature
-The Liberty MCP Server feature enables a Liberty server to communicate with agentic AI workflows through the MCP protocol. This protocol provides a standardized way for AI applications to discover and utilize the business logic within your application.
+== How to Use the Liberty MCP Server Beta Feature
+The Liberty MCP Server beta feature enables a Liberty server to communicate with agentic AI workflows through the MCP protocol. This protocol provides a standardized way for AI applications to discover and utilize the business logic within your application.
 
 The MCP endpoint is available at `/mcp` under your application's context root. For example, if you see this in your logs:
 ```
@@ -45,7 +45,7 @@ To test your MCP server, you can use the https://modelcontextprotocol.io/docs/to
 === Declaring an MCP Tool
 To expose your business logic to authorized AI applications, you'll need to declare it as an https://modelcontextprotocol.io/specification/2025-06-18/server/tools[MCP tool]. In this context, a tool is a function or operation that the AI can invoke to perform a specific task.
 
-You can easily declare a tool with the Liberty MCP Server feature by adding the `@Tool` annotation to your desired Java method. This annotation makes your method automatically discoverable by the Liberty MCP Server feature to make the method available for AI applications to invoke. 
+You can easily declare a tool with the Liberty MCP Server beta feature by adding the `@Tool` annotation to your desired Java method. This annotation makes your method automatically discoverable by the Liberty MCP Server beta feature to make the method available for AI applications to invoke.
 
 For this discovery mechanism to work, your Java method must be defined within a https://openliberty.io/docs/latest/cdi-beans.html[CDI managed bean] that has an appropriate scope annotation (e.g., `@ApplicationScoped` or `@RequestScoped`).
 
@@ -94,9 +94,9 @@ Note that the AI model will use the description to decide when to call a tool an
 
 
 == Supported MCP Functionality
-Much of the MCP specification's functionality is optional to implement, allowing for gradual adoption while maintaining compatibility. The `mcpServer-1.0` feature has implemented support for the tool feature of the MCP Server specification, along with the tool related capabilities listed below. 
+Much of the MCP specification's functionality is optional to implement, allowing for gradual adoption while maintaining compatibility. The `mcpServer-1.0` beta feature has implemented support for the tool feature of the MCP Server specification, along with the tool related capabilities listed below.
 
-The `mcpServer-1.0` feature supports communicating using both version https://modelcontextprotocol.io/specification/2025-06-18[2025-06-18] and version https://modelcontextprotocol.io/specification/2025-03-26[2025-03-26] of the MCP protocol.
+The `mcpServer-1.0` beta feature supports communicating using both version https://modelcontextprotocol.io/specification/2025-06-18[2025-06-18] and version https://modelcontextprotocol.io/specification/2025-03-26[2025-03-26] of the MCP protocol.
 
 === Tool Metadata hints (Annotations)
 You can provide hints about the scope and range of your tool to give the AI application an indication of how safe the tool is to call. For example, you can indicate whether calling your tool may modify data. Note that although the MCP specification refers to these hints as https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations["Tool Annotations"], they are unrelated to Java annotations.
@@ -137,8 +137,8 @@ public String bigComputationTool(Cancellation cancellation) {
 }
 ----
 
-== How to Try the MCP Server Feature
-Here are the simple steps to follow to try out the MCP Server feature `mcpServer-1.0`:
+== How to Try the MCP Server Beta Feature
+Here are the simple steps to follow to try out the MCP Server beta feature `mcpServer-1.0`:
 
 1. Download the Open Liberty All Beta Features package from https://openliberty.io/start/#runtime_betas[here]
 2. Unzip the archive. You should have a `wlp` folder


### PR DESCRIPTION
Make it clearer that the feature is in beta.

[Staging](https://blogs-staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/blog/2025/10/23/mcp-standalone-blog.html) looks good:
<img width="2191" height="5668" alt="image" src="https://github.com/user-attachments/assets/f0cfbb98-80d0-4abf-805e-0a9136bfe7b9" />
