### PR TITLE
Fix Error in MCP 25.0.0.11 beta blog

### DIFF
--- a/posts/2025-10-07-25.0.0.10.adoc
+++ b/posts/2025-10-07-25.0.0.10.adoc
@@ -10,6 +10,9 @@ seo-description: This release introduces support for the override library in the
 blog_description: This release introduces support for the override library in the application classloader that allows fixing applications without rebuilding them. It also adds compatibility with Java 25, the latest Long-Term Support (LTS) release of Java.
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
+blog-available-in-languages:
+- lang: ja
+  path: /ja/blog/2025/10/07/25.0.0.10.html
 ---
 = Support for override library in the application classloader and support for Java 25 in 25.0.0.10
 Navaneeth S Nair <https://github.com/navaneethsnair1>

--- a/posts/2025-10-21-25.0.0.11-beta.adoc
+++ b/posts/2025-10-21-25.0.0.11-beta.adoc
@@ -96,7 +96,7 @@ Here are the simple steps to follow to try out the new MCP Server 1.0 feature fo
     <artifactId>mcp-core</artifactId>
     <version>1.0.106</version>
     <scope>system</scope>
-    <systemPath>${wlp-dir-path}/lib/io.openliberty.mcp_1.0.106.jar}</systemPath>
+    <systemPath>${wlp-dir-path}/lib/io.openliberty.mcp_1.0.106.jar</systemPath>
 </dependency>
 ----
 5. Inside your `pom.xml` file, add the following plugin within the `plugins` block.

--- a/posts/2025-11-04-25.0.0.11.adoc
+++ b/posts/2025-11-04-25.0.0.11.adoc
@@ -10,6 +10,9 @@ seo-description: This GA release includes significant bug fixes that enhance sta
 blog_description: This GA release includes significant bug fixes that enhance stability, improve performance, and provide a smoother user experience.
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
+blog-available-in-languages:
+- lang: ja
+  path: /ja/blog/2025/11/04/25.0.0.11.html
 ---
 = Notable bug fixes in 25.0.0.11
 Navaneeth S Nair <https://github.com/navaneethsnair1>

--- a/posts/2025-12-02-25.0.0.12.adoc
+++ b/posts/2025-12-02-25.0.0.12.adoc
@@ -10,6 +10,9 @@ seo-description: This release introduces support for supplying your own Base64-e
 blog_description: This release introduces support for supplying your own Base64-encoded AES-256 key, removing the need for Liberty to derive a key during startup and resulting in faster and more efficient password encryption. It also adds FIPS 140-3 compliance when Liberty running with appropriate IBM Semeru Runtime versions.
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
+blog-available-in-languages:
+- lang: ja
+  path: /ja/blog/2025/12/02/25.0.0.12.html
 ---
 = Bring your own AES-256 key, and support for FIPS 140-3 with IBM Semeru Runtimes in 25.0.0.12
 Navaneeth S Nair <https://github.com/navaneethsnair1>

--- a/posts/ja/2025-10-07-25.0.0.10.adoc
+++ b/posts/ja/2025-10-07-25.0.0.10.adoc
@@ -1,0 +1,196 @@
+---
+layout: post
+title: "25.0.0.10におけるアプリケーションクラスローダーでのオーバーライドライブラリのサポートとJava 25のサポート"
+# Do NOT change the categories section
+categories: blog
+author_picture: https://avatars3.githubusercontent.com/navaneethsnair1
+author_github: https://github.com/navaneethsnair1
+seo-title: アプリケーションクラスローダーでのオーバーライドライブラリのサポートとJava 25のサポート（25.0.0.10） - OpenLiberty.io
+seo-description: このリリースでは、アプリケーションを再ビルドせずに修正できるアプリケーションクラスローダーでのオーバーライドライブラリのサポートが導入されています。また、最新の長期サポート（LTS）リリースであるJava 25との互換性も追加されています。
+blog_description: このリリースでは、アプリケーションを再ビルドせずに修正できるアプリケーションクラスローダーでのオーバーライドライブラリのサポートが導入されています。また、最新の長期サポート（LTS）リリースであるJava 25との互換性も追加されています。
+open-graph-image: https://openliberty.io/img/twitter_card.jpg
+open-graph-image-alt: Open Liberty Logo
+additional_authors:
+- name: 馬場 剛 (翻訳)
+  github: https://github.com/babatch
+  image: https://avatars.githubusercontent.com/u/29302643
+blog-available-in-languages:
+- lang: en
+  path: /blog/2025/10/07/25.0.0.10.html
+---
+= 25.0.0.10におけるアプリケーションクラスローダーでのオーバーライドライブラリのサポートとJava 25のサポート
+Navaneeth S Nair <https://github.com/navaneethsnair1>
+:imagesdir: /
+:url-prefix:
+:url-about: /
+//Blank line here is necessary before starting the body of the post.
+ 
+このリリースでは、アプリケーションを再ビルドせずに修正できるアプリケーションクラスローダーでのオーバーライドライブラリのサポートが導入されています。また、最新の長期サポート（LTS）リリースであるJava 25との互換性も追加されています。
+
+// // // // // // // //
+// In the preceding section:
+// Leave any instances of `tag::xxxx[]` or `end:xxxx[]` as they are.
+//
+// Replace RELEASE_SUMMARY with a short paragraph that summarises the release. Start with the lead feature but also summarise what else is new in the release. You will agree which will be the lead feature with the reviewers so you can just leave a placeholder here until after the initial review.
+// // // // // // // //
+
+// // // // // // // //
+// Replace the following throughout the document:
+//   Replace 25.0.0.10 with the version number of Open Liberty, eg: 22.0.0.2
+//   Replace 250010 with the version number of Open Liberty wihtout the periods, eg: 22002
+// // // // // // // //
+
+link:{url-about}[Open Liberty] 25.0.0.10では:
+
+* <<overrideLibrary, アプリケーションクラスローダーでのオーバーライドライブラリのサポート>>
+* <<java_25, Java 25のサポート>>
+* <<CVEs, セキュリティ脆弱性（CVE）の修正>>
+
+link:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A250010+label%3A%22release+bug%22[25.0.0.10] で修正されたバグのリストをご覧ください。
+
+link:{url-prefix}/blog/?search=release&search!=beta[以前のOpen Liberty GAリリースのブログ記事] をチェックしてください。
+
+[#run]
+== 25.0.0.10を使用したアプリケーションの開発と実行
+
+link:{url-prefix}/guides/maven-intro.html[Maven] を使用している場合は、 `pom.xml` ファイルに以下を含めてください:
+
+[source,xml]
+----
+<plugin>
+    <groupId>io.openliberty.tools</groupId>
+    <artifactId>liberty-maven-plugin</artifactId>
+    <version>3.11.5</version>
+</plugin>
+----
+
+または、link:{url-prefix}/guides/gradle-intro.html[Gradle] の場合は、 `build.gradle` ファイルに以下を含めてください:
+
+[source,gradle]
+----
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.9.5'
+    }
+}
+apply plugin: 'liberty'
+----
+
+または、link:{url-prefix}/docs/latest/container-images.html[コンテナイメージ] を使用している場合:
+
+[source]
+----
+FROM icr.io/appcafe/open-liberty
+----
+
+または、link:{url-prefix}/start/[ダウンロードページ] をご覧ください。
+
+link:https://plugins.jetbrains.com/plugin/14856-liberty-tools[IntelliJ IDEA]、link:https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext[Visual Studio Code]、または link:https://marketplace.eclipse.org/content/liberty-tools[Eclipse IDE] を使用している場合は、オープンソースの link:https://openliberty.io/docs/latest/develop-liberty-tools.html[Liberty開発ツール] を活用して、IDE内での効果的な開発、テスト、デバッグ、アプリケーション管理を行うことができます。
+
+[link=https://stackoverflow.com/tags/open-liberty]
+image::img/blog/blog_btn_stack.svg[Open Libertyについて質問する, align="center"]
+
+// // // // DO NOT MODIFY THIS COMMENT BLOCK <GHA-BLOG-TOPIC> // // // // 
+// Blog issue: https://github.com/OpenLiberty/open-liberty/issues/33003
+// Contact/Reviewer: tjwatson
+// // // // // // // // 
+[#overrideLibrary]
+== アプリケーションクラスローダーでのオーバーライドライブラリのサポート
+
+このGAリリースでは、オーバーライドライブラリ参照を設定するために使用できるアプリケーションの `<classloader/>` を設定するための新しいタイプのライブラリ参照が導入されています。オーバーライドライブラリ参照は、クラスインスタンスがアプリケーションのクラスローダーに固有のままであるため、プライベートライブラリ参照に似ています。主な違いは検索順序です。オーバーライドライブラリ参照では、ライブラリクラスパスはアプリケーション自身のクラスパスの前に検索されます。したがって、オーバーライドライブラリを使用すると、ライブラリパスがアプリケーションに既に含まれているクラスをオーバーライドできます。
+
+例えば、 `<webApplication/>` に `org.acme.needs.fix.SomeImpl` のような修正が必要なクラスが含まれているとします。アプリケーションを再ビルドして修正を含めることが難しい、または望ましくない場合は、修正されたクラスファイルを含む新しいライブラリJAR（例： `someImplFix.jar` ）をビルドします。以下の `server.xml` 設定は、アプリケーションを再ビルドせずに修正を適用するために `overrideLibraryRef` を使用する方法を示しています:
+
+[source, xml]
+----
+<webApplication location="appThatNeedsFix.war">
+    <classloader overrideLibraryRef="someImplFix"/>
+</webApplication>
+
+<library id="someImplFix">
+     <path name="someImplFix.jar"/>
+</library>
+----
+
+   
+// DO NOT MODIFY THIS LINE. </GHA-BLOG-TOPIC> 
+
+// // // // DO NOT MODIFY THIS COMMENT BLOCK <GHA-BLOG-TOPIC> // // // // 
+// Blog issue: https://github.com/OpenLiberty/open-liberty/issues/32929
+// Contact/Reviewer: gjwatts
+// // // // // // // // 
+[#java_25]
+== Java 25のサポート
+
+Java 25は、最新の長期サポート（LTS）リリースであり、以前のバージョンのJavaと比較して多くの新機能と拡張機能が含まれています。
+link:https://openjdk.org/projects/jdk/25/[Java 25] には18の新機能（JEP）があります：6つはテスト機能で、12は完全に提供されています。
+
+**テスト機能**
+
+* 470:    link:https://openjdk.org/jeps/470[暗号オブジェクトのPEMエンコーディング（プレビュー）]
+* 502:    link:https://openjdk.org/jeps/502[安定値（プレビュー）]
+* 505:    link:https://openjdk.org/jeps/505[構造化並行処理（第5プレビュー）]
+* 507:    link:https://openjdk.org/jeps/507[パターン、instanceof、およびスイッチでのプリミティブ型（第3プレビュー）]
+* 508:    link:https://openjdk.org/jeps/508[ベクトルAPI（第10インキュベータ）]
+* 509:    link:https://openjdk.org/jeps/509[JFR CPUタイムプロファイリング（実験的）]
+
+**提供済み機能**
+
+* 503:    link:https://openjdk.org/jeps/503[32ビットx86ポートの削除]
+* 506:    link:https://openjdk.org/jeps/506[スコープ付き値]
+* 510:    link:https://openjdk.org/jeps/510[鍵導出関数API]
+* 511:    link:https://openjdk.org/jeps/511[モジュールインポート宣言]
+* 512:    link:https://openjdk.org/jeps/512[コンパクトソースファイルとインスタンスメインメソッド]
+* 513:    link:https://openjdk.org/jeps/513[柔軟なコンストラクタ本体]
+* 514:    link:https://openjdk.org/jeps/514[事前コンパイル（AOT）コマンドラインエルゴノミクス]
+* 515:    link:https://openjdk.org/jeps/515[事前コンパイル（AOT）メソッドプロファイリング]
+* 518:    link:https://openjdk.org/jeps/518[JFR協調サンプリング]
+* 519:    link:https://openjdk.org/jeps/519[コンパクトオブジェクトヘッダー]
+* 520:    link:https://openjdk.org/jeps/520[JFRメソッドタイミングとトレーシング]
+* 521:    link:https://openjdk.org/jeps/521[世代別Shenandoah]
+
+Java 25で明示的なExecutorバッキングなしで `CompletableFuture` および `SubmissionPublisher` クラスを使用する場合、デフォルトでは `ForkJoinPool.commonPool` を使用します。このプールは、並列処理の値を利用可能なプロセッサ数から1を引いた値（利用可能なプロセッサ数 - 1）に設定します。2つ以下のプロセッサを持つシステムで実行されるアプリケーションは、Java 25がデフォルトで単一のスレッドのみを使用するため、並行処理の問題が発生する可能性があります。以前のJavaバージョンでは、 `ForkJoinPool` 共通プールの並列処理値が2未満の場合、JDKは各非同期タスクに対して新しいスレッドを作成していたため、これは問題ではありませんでした。
+
+以下のアプローチのいずれかを使用して、この問題を回避できます:
+
+  . この制限のないLibertyのJakarta Concurrency実装で提供される `CompletableFuture` クラスを使用します。 `CompletableFuture` クラスを link:https://www.ibm.com/docs/en/was-liberty/core?topic=manually-configuring-managed-executors[DefaultManagedExecutorService] インスタンスと、link:https://jakarta.ee/specifications/concurrency/3.1/apidocs/jakarta.concurrency/jakarta/enterprise/concurrent/managedexecutorservice#supplyAsync(java.util.function.Supplier)[supplyAsync] メソッドまたは link:https://jakarta.ee/specifications/concurrency/3.1/apidocs/jakarta.concurrency/jakarta/enterprise/concurrent/managedexecutorservice#runAsync(java.lang.Runnable)[runAsync] メソッドのいずれかと一緒に使用できます。
+  . システムプロパティ `-Djava.util.concurrent.ForkJoinPool.common.parallelism=N` （Nは必要な最小スレッド数）を使用して、 `ForkJoinPool.commonPool` の並列処理値を明示的に設定します。
+  . 明示的なバッキング `Executor` を使用します。
+
+この変更の詳細については、以下のリンクを参照してください:
+
+* https://bugs.openjdk.org/browse/JDK-8362881
+* https://bugs.openjdk.org/browse/JDK-8319447
+* https://bugs.openjdk.org/browse/JDK-8360593
+
+Open LibertyでJava 25の変更を今すぐ活用し、お気に入りのサーバーランタイムでアプリケーション、マイクロサービス、ランタイム環境をレビューする時間を増やしましょう！
+
+link:https://adoptium.net/temurin/releases/?version=25[Java 25の最新リリースをダウンロード] し、link:https://openliberty.io/start/#runtime_releases[25.0.0.10] バージョンのOpen Libertyをダウンロードしてインストールし、LibertyサーバーのJAVA_HOMEをJava 25インストールディレクトリに設定した link:https://openliberty.io/docs/latest/reference/config/server-configuration-overview.html#server-env[server.env] ファイルを編集してテストを開始しましょう！
+
+Java 25の詳細については、Java 25の link:https://jdk.java.net/25/release-notes[リリースノートページ] 、link:https://docs.oracle.com/en/java/javase/25/docs/api/index.html[API Javadocページ] 、または link:https://adoptium.net/temurin/releases/?version=25[ダウンロードページ] をご覧ください。
+Open Libertyの詳細については、link:https://openliberty.io/docs[ドキュメントページ] をご覧ください。
+
+   
+// DO NOT MODIFY THIS LINE. </GHA-BLOG-TOPIC> 
+
+[#CVEs]
+== このリリースでのセキュリティ脆弱性（CVE）の修正
+[cols="5*"]
+|===
+|CVE |CVSSスコア |脆弱性評価 |影響を受けるバージョン |注記
+
+|https://www.cve.org/CVERecord?id=CVE-2020-36732[CVE-2020-36732]
+|5.3
+|セキュリティの弱体化
+|17.0.0.3-25.0.0.9
+| `openidConnectServer-1.0` 機能に影響します
+|===
+
+過去のセキュリティ脆弱性修正のリストについては、link:{url-prefix}/docs/latest/security-vulnerabilities.html[セキュリティ脆弱性（CVE）リスト] を参照してください。
+
+== Open Liberty 25.0.0.10を今すぐ入手
+
+<<run,Maven、Gradle、Docker、およびダウンロード可能なアーカイブ>> を通じて利用可能です。

--- a/posts/ja/2025-11-04-25.0.0.11.adoc
+++ b/posts/ja/2025-11-04-25.0.0.11.adoc
@@ -1,0 +1,165 @@
+---
+layout: post
+title: "25.0.0.11 における注目すべきバグ修正"
+# Do NOT change the categories section
+categories: blog
+author_picture: https://avatars3.githubusercontent.com/navaneethsnair1
+author_github: https://github.com/navaneethsnair1
+seo-title: 25.0.0.11 における注目すべきバグ修正 - OpenLiberty.io
+seo-description: この GA リリースには、安定性を向上させ、パフォーマンスを改善し、よりスムーズなユーザー・エクスペリエンスを提供する重要なバグ修正が含まれています。
+blog_description: この GA リリースには、安定性を向上させ、パフォーマンスを改善し、よりスムーズなユーザー・エクスペリエンスを提供する重要なバグ修正が含まれています。
+open-graph-image: https://openliberty.io/img/twitter_card.jpg
+open-graph-image-alt: Open Liberty Logo
+blog-available-in-languages:
+- lang: en
+  path: /blog/2025/11/04/25.0.0.11.html
+additional_authors:
+- name: 高宮 裕子 (翻訳)
+  github: https://github.com/una-tapa
+  image: https://avatars0.githubusercontent.com/una-tapa
+---
+= 25.0.0.11 における注目すべきバグ修正
+Navaneeth S Nair <https://github.com/navaneethsnair1>
+:imagesdir: /
+:url-prefix:
+:url-about: /
+
+この GA リリースには、安定性を向上させ、パフォーマンスを改善し、よりスムーズなユーザー・エクスペリエンスを提供する重要なバグ修正が含まれています。
+
+* <<bugs, 注目すべきバグ修正>>
+
+link:{url-prefix}/blog/?search=release&search!=beta[以前の Open Liberty GA リリースのブログ投稿] もチェックして下さい。
+
+[#run]
+
+== 25.0.0.11 でアプリを開発して実行する
+
+もし link:{url-prefix}/guides/maven-intro.html[Maven] を使用しているなら、`pom.xml` に以下を含めます。
+
+[source,xml]
+----
+<plugin>
+    <groupId>io.openliberty.tools</groupId>
+    <artifactId>liberty-maven-plugin</artifactId>
+    <version>3.11.5</version>
+</plugin>
+----
+
+link:{url-prefix}/guides/gradle-intro.html[Gradle] を使用している場合は、`build.gradle` ファイルに以下を含めます。
+
+[source,gradle]
+----
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.9.5'
+    }
+}
+apply plugin: 'liberty'
+----
+
+link:{url-prefix}/docs/latest/container-images.html[コンテナ・イメージ] を使用する場合は以下です。
+
+[source]
+----
+FROM icr.io/appcafe/open-liberty
+----
+
+もしくは link:{url-prefix}/start/[ダウンロード・ページ] をご覧下さい。
+
+link:https://plugins.jetbrains.com/plugin/14856-liberty-tools[IntelliJ IDEA]、link:https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext[Visual Studio Code] または link:https://marketplace.eclipse.org/content/liberty-tools[Eclipse IDE] を使用している場合、これらの IDE で効率的な開発・テスト・デバッグとアプリケーション管理のすべてを実行するために、オープンソースの link:https://openliberty.io/docs/latest/develop-liberty-tools.html[Liberty Tools] を利用することができます。
+
+[link=https://stackoverflow.com/tags/open-liberty]
+image::img/blog/blog_btn_stack_ja.svg[Stack Overflow で質問する, align="center"]
+
+// // // // // // // //
+// In the preceding section:
+// If there were any CVEs addressed in this release, fill out the table.  For the information, reference https://github.com/OpenLiberty/docs/blob/draft/modules/ROOT/pages/security-vulnerabilities.adoc.  If it has not been updated for this release, reach out to Kristen Clarke or Michal Broz.
+// Note: When linking to features, use the 
+// `link:{url-prefix}/docs/latest/reference/feature/someFeature-1.0.html[Some Feature 1.0]` format and 
+// NOT what security-vulnerabilities.adoc does (feature:someFeature-1.0[])
+//
+// If there are no CVEs fixed in this release, replace the table with: 
+// "There are no security vulnerability fixes in Open Liberty [25.0.0.11]."
+// // // // // // // //
+
+[#bugs]
+== このリリースで修正された注目すべきバグ
+
+このリリースでは、いくつかのバグが修正されました。以下のセクションでは、解決された主要な問題のいくつかを紹介します。修正の完全なリストについては、link:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A250011+label%3A%22release+bug%22[25.0.0.11 で修正されたバグの完全なリスト] をご覧ください。
+
+* link:https://github.com/OpenLiberty/open-liberty/issues/33098[JSON レコードが改行で終わる場合に `appsWriteJSON` が正しく動作しない]
++
+Logback ロギング・フレームワークを使用し、ロガーがメッセージを JSON 形式に変換するエンコーダー（例：`co.elastic.logging.logback.EcsEncoder`）を使用して `STDOUT` にロギング・イベントをルーティングするように設定されている場合、メッセージ全体は _改行_ で終わります。
++
+`appsWriteJson` 設定が true に設定されている OpenLiberty サーバーと組み合わせた場合、期待される動作は、Logback から出力される JSON が、通常の Open Liberty JSON ログ出力の `message` 値内にラップされないことです。しかし、実際にはラップされてしまいます。
+
+* link:https://github.com/OpenLiberty/open-liberty/issues/32999[マルチパート・データの非同期呼び出しにおける例外を修正]
++
+MicroProfileRestClient の非同期で multipart/form-data を送信すると、以下の例外が発生します。
++
+`java.util.concurrent.CompletionException: jakarta.ws.rs.ProcessingException: RESTEASY004655: Unable to invoke request: jakarta.ws.rs.WebApplicationException: Unexpected entity instance: org.jboss.resteasy.plugins.providers.multipart.ResteasyEntityPartBuilder$EntityPartImpl`
+
+* link:https://github.com/OpenLiberty/open-liberty/issues/32954[AutoDecompress が正しく動作しない]
++
+圧縮されたボディを持つ POST リクエストで、以下の例外が発生します。
++
+`SRVE0216E: post body contains less bytes than specified by content-length` 
+
+* link:https://github.com/OpenLiberty/open-liberty/issues/32908[設計上の問題：英数字以外の文字を含むサーバー名での `server create` の動作が一貫していない]
++
+`./server create ...` を使用してサーバーを作成する際、サーバー名に英数字以外の文字（ドキュメントで指定されていない文字）が含まれている場合、動作が一貫していません。
++
+例えば：
++
+```
+./server create 'this£server'
+```
++
+は以下を返します：
++
+```
+CWWKE0005E: The runtime environment could not be launched.
+CWWKE0012E: The specified server name contains a character that is not valid (name=this£server). Valid characters are: Unicode alphanumeric (e.g. 0-9, a-z, A-Z), underscore (_), dash (-), plus (+), and period (.). A server name cannot begin with a dash (-) or period (.).
+```
++
+しかし
++
+```
+./server create 'this$server'
+```
++
+は以下を返します：
++
+```
+Server this created.
+```
++
+また、サーバー名に空白が含まれている場合、サーバー名が引用符で囲まれているかどうかに関わらず、最初の空白の前のテキストを使用してサーバーが作成されます。例えば：
++
+```
+./server create 'this server'
+```
++
+は以下を返します：
++
+```
+CWWKE0027W: Only one server may be specified on the command line; subsequent names will be ignored (server=this, ignored=server).
+Server this created.
+```
+
+* link:https://github.com/OpenLiberty/open-liberty/issues/31628[カスタム Subject がキャッシュにない場合の継続的な認証をサポート]
++
+シングル・サインオン（SSO）環境では、ユーザーは特定の管理タスクを実行するために、アプリケーション内で一時的に権限を管理者レベルに昇格させる必要がある場合があります。しかし、AuthenticationException によってこのシナリオが正常に機能しません。
++
+この問題は、LTPA（Lightweight Third-Party Authentication）トークンが有効であるにもかかわらず発生します - トークンは正常に復号化および解析でき、有効期限と署名の両方が適切に検証されます。
++
+認証の失敗は、WebSphere Liberty サーバーが認証キャッシュ内で昇格されたユーザーの Subject を見つけることができないために発生し、権限昇格プロセス中に認証が失敗します。
++
+この制限により、同じ SSO セッション内で一時的な権限昇格が必要なシナリオでの正当な管理操作が妨げられます。
+
+== 今すぐ Open Liberty 25.0.0.11 を入手する
+
+<<run,Maven, Gradle, Docker, そしてダウンロード可能なアーカイブ>> から可能です。

--- a/posts/ja/2025-12-02-25.0.0.12.adoc
+++ b/posts/ja/2025-12-02-25.0.0.12.adoc
@@ -1,0 +1,357 @@
+---
+layout: post
+title: "25.0.0.12 で独自の AES-256 キーの持ち込みと、IBM Semeru Runtimes による FIPS 140-3 のサポート"
+# Do NOT change the categories section
+categories: blog
+author_picture: https://avatars3.githubusercontent.com/navaneethsnair1
+author_github: https://github.com/navaneethsnair1
+seo-title: 25.0.0.12 で独自の AES-256 キーの持ち込みと、IBM Semeru Runtimes による FIPS 140-3 のサポート - OpenLiberty.io
+seo-description: このリリースでは、独自の Base64 エンコードされた AES-256 キーを提供するサポートが導入され、起動時に Liberty がキーを導出する必要がなくなり、より高速で効率的なパスワード暗号化が実現されます。また、適切な IBM Semeru Runtime バージョンで Liberty を実行する際の FIPS 140-3 準拠が追加されます。
+blog_description: このリリースでは、独自の Base64 エンコードされた AES-256 キーを提供するサポートが導入され、起動時に Liberty がキーを導出する必要がなくなり、より高速で効率的なパスワード暗号化が実現されます。また、適切な IBM Semeru Runtime バージョンで Liberty を実行する際の FIPS 140-3 準拠が追加されます。
+open-graph-image: https://openliberty.io/img/twitter_card.jpg
+open-graph-image-alt: Open Liberty Logo
+blog-available-in-languages:
+- lang: en
+  path: /blog/2025/12/02/25.0.0.12.html
+additional_authors:
+- name: 高宮 裕子 (翻訳)
+  github: https://github.com/una-tapa
+  image: https://avatars.githubusercontent.com/una-tapa
+---
+= 25.0.0.12 で独自の AES-256 キーの持ち込みと、IBM Semeru Runtimes による FIPS 140-3 のサポート
+Navaneeth S Nair <https://github.com/navaneethsnair1>
+:imagesdir: /
+:url-prefix:
+:url-about: /
+//Blank line here is necessary before starting the body of the post.
+ 
+このリリースでは、独自の Base64 エンコードされた AES-256 キーを提供するサポートが導入され、起動時に Liberty がキーを導出する必要がなくなり、より高速で効率的なパスワード暗号化が実現されます。また、サポートされている IBM Semeru Runtime バージョン（11.0.29、17.0.17、21.0.9、25.0.1 以降）で Liberty を実行する際の FIPS 140-3 準拠が追加されます。
+
+// // // // // // // //
+// In the preceding section:
+// Leave any instances of `tag::xxxx[]` or `end:xxxx[]` as they are.
+//
+// Replace RELEASE_SUMMARY with a short paragraph that summarises the release. Start with the lead feature but also summarise what else is new in the release. You will agree which will be the lead feature with the reviewers so you can just leave a placeholder here until after the initial review.
+// // // // // // // //
+
+// // // // // // // //
+// Replace the following throughout the document:
+//   Replace 25.0.0.12 with the version number of Open Liberty, eg: 22.0.0.2
+//   Replace 250010 with the version number of Open Liberty wihtout the periods, eg: 22002
+// // // // // // // //
+
+In link:{url-about}[Open Liberty] 25.0.0.12:
+
+* <<aes256, 独自の AES-256 キーの持ち込み>>
+* <<fips, IBM Semeru Runtimes による FIPS 140-3 のサポート>>
+* <<CVEs, セキュリティ脆弱性（CVE）の修正>>
+
+25.0.0.12 で修正されたバグのリストは link:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A250010+label%3A%22release+bug%22[こちら] です。
+
+link:{url-prefix}/blog/?search=release&search!=beta[以前の Open Liberty GA リリースのブログ投稿] もチェックして下さい。
+
+[#run]
+== 25.0.0.12 でアプリを開発して実行する
+
+もし link:{url-prefix}/guides/maven-intro.html[Maven] を使用しているなら、`pom.xml` に以下を含めます。
+
+[source,xml]
+----
+<plugin>
+    <groupId>io.openliberty.tools</groupId>
+    <artifactId>liberty-maven-plugin</artifactId>
+    <version>3.11.5</version>
+</plugin>
+----
+
+link:{url-prefix}/guides/gradle-intro.html[Gradle] を使用している場合は、`build.gradle` ファイルに以下を含めます。
+
+[source,gradle]
+----
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.9.6'
+    }
+}
+apply plugin: 'liberty'
+----
+
+link:{url-prefix}/docs/latest/container-images.html[コンテナ・イメージ] を使用する場合は以下です。
+
+[source]
+----
+FROM icr.io/appcafe/open-liberty
+----
+
+もしくは link:{url-prefix}/start/[ダウンロード・ページ] をご覧下さい。
+
+link:https://plugins.jetbrains.com/plugin/14856-liberty-tools[IntelliJ IDEA]、link:https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext[Visual Studio Code] または link:https://marketplace.eclipse.org/content/liberty-tools[Eclipse IDE] を使用している場合、これらの IDE で効率的な開発・テスト・デバッグとアプリケーション管理のすべてを実行するために、オープンソースの link:https://openliberty.io/docs/latest/develop-liberty-tools.html[Liberty Tools] を利用することができます。
+
+[link=https://stackoverflow.com/tags/open-liberty]
+image::img/blog/blog_btn_stack_ja.svg[Stack Overflow で質問する, align="center"]
+
+// // // // DO NOT MODIFY THIS COMMENT BLOCK <GHA-BLOG-TOPIC> // // // // 
+// Blog issue: https://github.com/OpenLiberty/open-liberty/issues/33391
+// Contact/Reviewer: jacobwdv
+// // // // // // // // 
+[#aes256]
+== 独自の AES-256 キーの持ち込み
+
+Liberty では、パスワード暗号化のために Base64 エンコードされた 256 ビット AES キーを提供できるようになりました。
+
+=== 新機能
+
+以前、Liberty は `wlp.password.encryption.key` プロパティをサポートしており、パスワードを受け取り、計算集約的なプロセスを通じて AES キーを導出していました。この導出には、ソルトを使用した繰り返しハッシュが多数の反復にわたって含まれており、サーバー起動時にオーバーヘッドが追加されていました。
+
+現在では、事前に生成された AES キーを直接提供できるようになりました。これにより導出ステップが不要になり、起動時間が短縮され、パスワードの暗号化と復号化時のランタイム・パフォーマンスが向上します。
+
+=== 有効化の方法
+
+. **256 ビット AES キーの取得** 
++
+セキュリティ・インフラストラクチャから 256 ビット AES キーを取得するか、`securityUtility generateAESKey` コマンドを使用して生成できます。
++
+`securityUtility` を使用して 256 ビット AES キーを生成するには、新しい `securityUtility generateAESKey` タスクを実行します：
+
+* ランダムな AES キーを生成する： 
++
+```bash
+./securityUtility generateAESKey
+```
+* オプションで、ランダムな AES キーを XML ファイルに保存する：
++
+```bash
+  securityUtility generateAESKey --createConfigFile=myAesConfig.xml
+```
+* または、パスフレーズから非ランダムな AES キーを生成する： 
++ 
+```bash
+./securityUtility generateAESKey --key=<password>
+```
+* オプションで、パスフレーズから非ランダムな AES キーを生成し、XML ファイルに保存する：
++
+```bash
+  securityUtility generateAESKey --key=<password> --createConfigFile=myAesConfig.xml
+```
+
+. *Liberty でキーを設定する* 
++
+`server.xml` ファイルで AES キーを直接設定するには、以下の変数定義を追加します：
++ 
+[source, xml]
+----
+   <variable name="wlp.aes.encryption.key" value="<your_aes_key>" />
+----
++
+または、外部設定ファイル（`generateAESKey --createConfigFile` で生成されたファイルなど）から AES キーをロードするには、以下の設定を使用してファイルをインクルードします。
++
+*注意：* インクルードされるファイルには、前述のように `wlp.aes.encryption.key` の変数定義が含まれている必要があります。
++
+[source, xml]
+----
+    <include location="/path/to/myAesConfig.xml" />
+----
+
+. *パスワードを暗号化する*
++
+`securityUtility encode` コマンドを実行して、AES-256 キーを使用するパスワードを暗号化できます：
+
+- キーを直接提供する：
++
+```bash
+securityUtility encode --encoding=aes --base64Key=<your_base64_key> <password>
+```
+- AES キー変数を含む XML または Java プロパティ・ファイルを使用するには、`--aesConfigFile` オプションを指定します：
++
+```bash
+securityUtility encode --encoding=aes --aesConfigFile=<xml_or_properties_file_path> <password>
+```
+. *設定を更新する*
++
+結果として得られた暗号化された値を Liberty 設定にコピーします。
+
+---
+
+*パフォーマンスのヒント：* 最高のパフォーマンスを得るには、新しい AES-256 キーを使用してすべてのパスワードを再暗号化してください。Open Liberty は古いパスワード形式をサポートしていますが、完全な移行により一貫した起動パフォーマンスが提供されます。
+
+AES 暗号化をサポートする Liberty コマンドは、以下のオプションを受け入れます：
+
+* `--base64Key` または `--passwordBase64Key`：Base64 エンコードされた AES-256 キーを直接提供します。
+* `--aesConfigFile`：`wlp.aes.encryption.key` または `wlp.password.encryption.key` を定義する設定ファイルを提供します。
+
+その他のコマンドライン・タスクも、同様の方法で Base64 キーと AES 設定ファイルを受け入れるように更新されています：
+
+. `securityUtility`
+  * `createSSLCertificate`
+  * `createLTPAKeys`
+  * `encode`
+. `configUtility`
+  * `install`
+. `collective`
+  * `create`
+  * `join`
+  * `replicate`
+   
+// DO NOT MODIFY THIS LINE. </GHA-BLOG-TOPIC> 
+
+// // // // DO NOT MODIFY THIS COMMENT BLOCK <GHA-BLOG-TOPIC> // // // // 
+// Blog issue: https://github.com/OpenLiberty/open-liberty/issues/33359
+// Contact/Reviewer: abutch3r
+// // // // // // // // 
+[#fips]
+== IBM Semeru Runtimes による FIPS 140-3 のサポート
+
+FIPS 140-3 は FIPS 140 標準の最新バージョンであり、暗号化モジュールのセキュリティと整合性を確保するための一連のガイドラインを提供します。FIPS 140-3 のサポートは、バージョン link:https://openliberty.io/blog/2025/03/25/25.0.0.3.html[25.0.0.3] で IBM JDK 8 を使用した Liberty で初めて導入されました。このリリースでは、Open Liberty は link:https://developer.ibm.com/languages/semeru-runtimes[IBM Semeru Runtimes] バージョン 11.0.29、17.0.17、21.0.9、25.0.1 以降を使用する際に FIPS 140-3 標準をサポートします。
+
+=== FIPS 140-3 の有効化
+
+`securityUtility` には、FIPS 140-3 を有効にするための configureFIPS という新しいタスクがあります。この新しいタスクは、IBM Semeru Runtimes と IBM SDK 8 の両方に適用されます。
+
+`configureFIPS` タスクは 3 つのレベルで動作します：
+
+1. Install
+2. Server
+3. Client
+
+すべてのサーバー、クライアント、およびツール全体で有効にするには、以下を実行して Install レベルで FIPS 140-3 を有効にできます：
+```
+securityUtility configureFIPS
+```
+
+特定のサーバーを有効化または設定するには、以下を実行します：
+```
+securityUtility configureFIPS --server=<server name>
+```
+
+特定のクライアントを有効化または設定するには、以下を実行します：
+```
+securityUtility configureFIPS --client=<client name>
+```
+
+IBM Semeru Runtimes の場合、これらのコマンドは FIPS 有効化要件を設定し、アプリケーションの必要な制約を設定するために編集できる Java セキュリティ・プロパティ・ファイルを作成します。
+制約の設定の詳細については、link:https://www.ibm.com/support/pages/node/7113528#creatingextensionsofprofiles[プロファイルの拡張の作成] に関するドキュメントを参照してください。
+
+特定の場所または特定の名前でプロファイルを作成するには、`--customProfileFile=<file path (or paths) separated by the OS-specific path separator>` 引数を指定でき、編集可能なファイルが作成されます。ファイルの名前がプロファイルの名前として使用されます。設定は、提供されたファイルを指すように設定されます。
+プロパティには複数のファイルを指定できます。すべてのファイルが作成され、前のファイルを拡張し、指定された最後のファイルがチェーンの最後になります。
+
+`securityUtility configureFIPS` コマンドの一部として `--customProfileFile` を指定しない場合、ファイルは以下の場所に作成されます。場所は、サーバーまたはクライアントを指定したかどうかによって異なります。
+
+- サーバーもクライアントも指定されていない場合 `<Liberty install location>/wlp/etc/FIPS140-3-Liberty-Application.properties`
+- サーバーが指定されている場合 `<server root>/resources/security/FIPS140-3-Liberty-Application.properties`
+- クライアントが指定されている場合 `<client root>/resources/security/FIPS140-3-Liberty-Application.properties`
+
+有効化されている必要なレベルで FIPS 140-3 を無効にするには、コマンドに以下のオプションを追加します。
+```
+--disable 
+```
+
+=== LTPA
+
+FIPS 140-3 が有効になっている場合、サーバーは FIPS 140-3 承認の暗号化アルゴリズムを使用して生成された LTPA キーのみをロードできます。LTPA シングル・サインオン（SSO）を機能させるには、ユーザーはすべてのサーバーで FIPS 140-3 を使用するように設定する必要があります。設定の詳細については、link:https://www.ibm.com/docs/en/was-liberty/base?topic=liberty-configuring-ltpa-in[ドキュメント] を参照してください。
+
+FIPS 140-3 が有効化された後にサーバーが再起動されると、FIPS 承認アルゴリズムで生成された新しい `ltpa.keys` ファイルが自動的に作成されます。FIPS 140-3 が有効化される前に作成された既存の `ltpa.keys` ファイルは、`ltpa.keys.nofips` にバックアップされます。
+お客様は、FIPS 140-3 が有効化される前に作成された検証キー・ファイルを再作成するために、securityUtility `createLTPAKeys` コマンドを使用する必要があります。
+
+==== securityUtility を使用した新しい FIPS 承認 LTPA キーの作成： 
+
+securityUtility コマンドの `createLTPAKeys` オプションを使用して LTPA キーを作成することもできます。FIPS 140-3 承認アルゴリズムで LTPA キーを生成するには、インストール・レベルで FIPS 140-3 を設定します。
+```
+securityUtility createLTPAKeys --password=mypassword --passwordEncoding=aes
+```
+
+=== SAML
+
+Liberty SAML Web Browser SSO 暗号化は、IBM Semeru FIPS 140-3 認定の ECDH-ES キー交換をサポートするようになりました。
+Liberty は、`SHA256`、`SHA384`、`SHA512`、および `ECDSAwithSHA256`、`ECDSAwith384`、`ECDSAwith512` を含む、SAML のより強力な署名アルゴリズムをサポートするようになりました。
+
+=== FIPS 140-3 モードが有効な場合にサポートされる署名メソッド・アルゴリズム・オプション
+*サポート対象：*
+
+- SHA256
+- SHA384（25.0.0.12 以降）
+- SHA512（25.0.0.12 以降）
+- ECDSAwithSHA256（25.0.0.12 以降）
+- ECDSAwithSHA384（25.0.0.12 以降）
+- ECDSAwithSHA512（25.0.0.12 以降）
+
+*サポート対象外：*
+
+- SHA1
+
+*使用例*
+```
+<samlWebSso20 id="defaultSP" signatureMethodAlgorithm="SHA256" />
+```
+
+=== FIPS 140-3 モードが有効な場合にサポートされる暗号化アルゴリズム
+*サポート対象：*
+
+- ECDH-ES
+
+*サポート対象外：*
+
+- SAML 暗号化が有効な場合の RSA-OAEP 暗号化キー転送。
+
+*注意：* IBM Semeru ランタイムで使用されている FIPS モジュールは、将来のリリースで RSA-OAEP 操作を認定する予定です。
+
+=== wsSecurity-1.1
+
+`wsSecurity-1.1` フィーチャーは、ECDH-ES アルゴリズムを活用して、署名と暗号化のための楕円曲線キーの使用をサポートするようになりました。
+
+=== アプリケーションの制約の定義
+
+FIPS 140-3 が設定されている場合、Semeru ランタイムは、link:https://www.ibm.com/support/pages/node/7113528#restrictedsecuritymode[FIPS140-3-Strongly-Enforced 制限付きセキュリティ・モード・プロファイル] が有効になっているときに、サーバー全体で FIPS 140-3 承認アルゴリズムの使用を強制します。Semeru FIPS 140-3 の暗号化アルゴリズムの強制は、アルゴリズムの使用を区別しません。たとえば、メッセージ・ダイジェスト・ハッシュ（通常は 2 つの値を比較するために使用される）での `SHA1` の使用は FIPS 140-3 仕様で許可されていますが、`SHA1` の使用に区別がないため、Semeru FIPS 140-3 は依然として例外をスローします。例外が発生した場合は常に、原因を調査し、必要に応じてアルゴリズムを更新してください（この場合、たとえば `SHA-256` または `SHA-512` に）。問題が暗号化に関連しておらず、その使用が FIPS 140-3 仕様で許可されている場合は、許可された制約としてカスタム・プロファイルの例外リストに追加してください。
+
+IBM Semeru は、プロファイルを使用して制約を適用し、Java セキュリティ・プロバイダーとアルゴリズムへのアクセスを許可して、FIPS 140-3 準拠を確保します。Strongly-enforced または Strict プロファイルがベースとして使用される場合、`SHA-1` などのアルゴリズムは、制約が追加されて許可されるまで、どのアプリケーション・クラスでも使用できません。
+
+`SHA-1` などの非 FIPS 140-3 メッセージ・ダイジェストを使用している場合、次のような例外が表示される場合があります：
+```
+java.security.NoSuchAlgorithmException: SHA1 MessageDigest not available
+	at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:159)
+	at java.base/java.security.MessageDigest.getInstance(MessageDigest.java:185)
+  at io.openliberty.fips.test.application.ObjectComparator.compareObjects(ObjectComparator.java:463)
+```
+アプリケーションがオブジェクトを比較しているため、`SHA-1` を使用できます。
+
+FIPS を有効にする一環として作成されたプロパティ・ファイルで、アルゴリズムを提供するプロバイダーの下に制約を追加できます。
+```
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty-Application.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS [+ \
+    {MessageDigest, SHA-1, *, FullClassName:io.openliberty.fips.test.application.ObjectComparator}]
+```
+*注意：* 例外では `SHA1` が欠落していると述べられていますが、アルゴリズムの名前は `SHA-1` であり、`SHA1` はそのエイリアスです。
+
+アプリケーションに Java セキュリティ・プロバイダーが含まれている場合、または `FIPS140-3-Liberty` または `FIPS140-3-Strongly-Enforced` プロファイルにまだ登録されていない新しいプロバイダーを追加する必要がある場合は、FIPS セキュリティ・プロパティ・ファイルにも含める必要があります。
+
+次のようにプロバイダーを追加できます：
+```
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty-Application.jce.provider.51 = io.openliberty.fips.test.custom.SecurityProvider
+```
+プロバイダーの定義内に制約を指定しない場合、そのプロバイダーが提供するすべてのアルゴリズムがランタイム内のすべてのクラスで使用可能になります。さらに、追加する新しいプロバイダーは、プロバイダー位置 51 から配置する必要があります。
+
+link:https://www.ibm.com/support/pages/fips-140-3-cryptography-ibm-semeru-runtimes[FIPS 140-3 サポート] および link:https://openliberty.io/docs/latest/reference/config/samlWebSso20.html[SAML Web Browser SSO] の詳細については、ドキュメントを参照してください。
+
+また、いくつかの異なるシナリオで追加する必要がある制約の例については、link:https://www.ibm.com/docs/en/was-liberty/nd?topic=liberty-troubleshooting-fips-140-3[トラブルシューティング] セクションを参照してください。
+
+// DO NOT MODIFY THIS LINE. </GHA-BLOG-TOPIC> 
+
+[#CVEs]
+== このリリースでのセキュリティ脆弱性（CVE）の修正
+[cols="5*"]
+|===
+|CVE |CVSS スコア |脆弱性評価 |影響を受けるバージョン |備考
+
+|https://www.cve.org/CVERecord?id=CVE-2025-7962[CVE-2025-7962]
+|7.5
+|SMTP インジェクション
+|17.0.0.3-25.0.0.11
+|`javaMail-1.5`、`javaMail-1.6`、`mail-2.0`、`mail-2.1` フィーチャーに影響
+|===
+
+過去のセキュリティ脆弱性修正のリストについては、link:{url-prefix}/docs/latest/security-vulnerabilities.html[セキュリティ脆弱性（CVE）リスト] を参照してください。
+
+== 今すぐ Open Liberty 25.0.0.12 を入手する
+
+<<run,Maven, Gradle, Docker, そしてダウンロード可能なアーカイブ>> から可能です。


### PR DESCRIPTION
Removes the extra `}` from mcp beta blog in the following code block:
`<systemPath>${wlp-dir-path}/lib/io.openliberty.mcp_1.0.106.jar}</systemPath>`