### PR TITLE
Fix release bug tags [staging branch]

### DIFF
--- a/posts/2025-12-02-25.0.0.12.adoc
+++ b/posts/2025-12-02-25.0.0.12.adoc
@@ -42,7 +42,7 @@ In link:{url-about}[Open Liberty] 25.0.0.12:
 * <<fips, Support for FIPS 140-3 with IBM Semeru Runtimes>>
 * <<CVEs, Security Vulnerability (CVE) Fixes>>
 
-View the list of fixed bugs in link:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A250010+label%3A%22release+bug%22[25.0.0.12].
+View the list of fixed bugs in link:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A250012+label%3A%22release+bug%22[25.0.0.12].
 
 Check out link:{url-prefix}/blog/?search=release&search!=beta[previous Open Liberty GA release blog posts].
 

--- a/posts/ja/2025-12-02-25.0.0.12.adoc
+++ b/posts/ja/2025-12-02-25.0.0.12.adoc
@@ -46,7 +46,7 @@ In link:{url-about}[Open Liberty] 25.0.0.12:
 * <<fips, IBM Semeru Runtimes による FIPS 140-3 のサポート>>
 * <<CVEs, セキュリティ脆弱性（CVE）の修正>>
 
-25.0.0.12 で修正されたバグのリストは link:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A250010+label%3A%22release+bug%22[こちら] です。
+25.0.0.12 で修正されたバグのリストは link:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A250012+label%3A%22release+bug%22[こちら] です。
 
 link:{url-prefix}/blog/?search=release&search!=beta[以前の Open Liberty GA リリースのブログ投稿] もチェックして下さい。
 


### PR DESCRIPTION
Fix release:250012 label references in release bug link.

Fix confirmed in https://blogs-draft-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/blog/2025/12/02/25.0.0.12.html