### PR TITLE
Repetitive sentences in 26.0.0.2 blog. 

### DIFF
--- a/posts/2026-02-24-26.0.0.2.adoc
+++ b/posts/2026-02-24-26.0.0.2.adoc
@@ -159,12 +159,7 @@ With Java Toolchains, you can now run your build tool on a modern JDK (for examp
 
 === Maven Plugin integration
 
-The Liberty Maven plugin now integrates seamlessly with the maven-toolchain-plugin. To use this feature, define your available JDKs in your `~/.m2/toolchains.xml` file. The plugin automatically detects and uses the toolchain that is specified in your project's `pom.xml` file.
-The Liberty Maven Plugin now integrates seamlessly with the maven-toolchain-plugin as of version 3.12.0.
-To use this feature, define your available JDKs in your `~/.m2/toolchains.xml` file and then configure `<jdkToolchain>` tag in `<configuration>`.
-
-The plugin automatically detects and uses the toolchain specified in your project’s `pom.xml` file.
-For detailed configuration steps and parameters, see the link:https://github.com/OpenLiberty/ci.maven/blob/main/docs/toolchain.md[Liberty Maven Plugin Toolchain documentation].
+The Liberty Maven Plugin now integrates with the maven-toolchain-plugin (as of version 3.12.0). To use this capability, define your available JDKs in `~/.m2/toolchains.xml` file, then configure `<jdkToolchain>` tag in `<configuration>`. The plugin will automatically detect and use the toolchain specified in your project’s pom.xml. For detailed configuration steps and parameters, see the link:https://github.com/OpenLiberty/ci.maven/blob/main/docs/toolchain.md[Liberty Maven Plugin Toolchain documentation].
 
 The plugin acknowledges the JDK vendor and version constraints that are defined in your Maven profiles, helping to ensure that your server environment remains consistent across different developer machines and CI/CD pipelines.
 


### PR DESCRIPTION
The reviewer reported the highlighted sentences appper twice , making this section hard to read and translate. 

> Maven Plugin integration
> **The Liberty Maven plugin now integrates seamlessly with the maven-toolchain-plugin.** To use this feature, define your available JDKs in your ~/.m2/toolchains.xml file. **The plugin automatically detects and uses the toolchain that is specified in your project’s pom.xml file**. **The Liberty Maven Plugin now integrates seamlessly with the maven-toolchain-plugin** as of version 3.12.0. **To use this feature, define your available JDKs in your ~/.m2/toolchains.xml file** and then configure <jdkToolchain> tag in <configuration>.
> 
> **The plugin automatically detects and uses the toolchain specified in your project’s pom.xml file.** For detailed configuration steps and parameters, see the [Liberty Maven Plugin Toolchain documentation](https://github.com/OpenLiberty/ci.maven/blob/main/docs/toolchain.md).