### PR TITLE
Add new blog post: Configuration steps for hardware cryptography for Liberty for Linux

### DIFF
--- a/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
+++ b/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
@@ -3,14 +3,17 @@ layout: post
 title: "Enabling hardware cryptography for Liberty for Linux on distributed environment with Semeru Java 17"
 # Do NOT change the categories section
 categories: blog
-author_picture: https://avatars3.githubusercontent.com/htakamiy
-author_github: https://github.ibm.com/htakamiy
+author_picture: https://avatars0.githubusercontent.com/una-tapa
+author_github: https://github.com/una-tapa
 seo-title: Enabling hardware cryptography for Liberty for Linux on distributed environment with Semeru Java 17
 seo-description: Enabling hardware cryptography for Liberty for Linux on distributed environment with Semeru Java 17. The configuration integrates Liberty with hardware security modules (HSM) for enhanced security.
 blog_description: "Enabling hardware cryptography for Liberty for Linux on distributed environment with Semeru Java 17. The configuration integrates Liberty with hardware security modules (HSM) for enhanced security."
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
 additional_authors: 
+- name: Laura Cowen
+  github: https://github.com/lauracowen
+  image: https://avatars3.githubusercontent.com/lauracowen
 - name: Jessie Zhou
   github: https://github.com/RoastedMilkTea
   image: https://avatars0.githubusercontent.com/RoastedMilkTea

--- a/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
+++ b/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
@@ -41,6 +41,7 @@ The customer's successful implementation used:
 
 These steps should be applicable for:
 - Liberty for Linux on distributed environment with other Java versions (Java 11, Java 21, etc.)
+
 Hardware cryptography, through hardware security modules (HSM), provides enhanced security for applications that are running on Liberty on distributed Linux environments. The following instructions to integrate Liberty on distributed Linux with hardware cryptographic devices were successfully tested by a customer who was using a Thales Luna HSM with Semeru Java 17. These instructions should also be applicable to other Java versions; see <<Java version considerations>> for potential modifications needed. The configuration should be adaptable to other hardware security modules that support the PKCS#11 interface.
 
 ## Example use cases 
@@ -59,7 +60,7 @@ The HSM integration with Liberty enables enhanced security for various cryptogra
 . Configure authentication between the Linux server and the HSM to establish secure communication.
 Create and register a self-signed client certificate, establishing mutual TLS as the authentication method.
 
-. *Create a PKCS#11 configuration file* that defines how Java will interact with the HSM through the PKCS#11 interface.
+. Create a PKCS#11 configuration file that defines how Java will interact with the HSM through the PKCS#11 interface.
 +
 For example, the following PKCS11Config.cfg file was created with assistance from Luna Support and saved in the Liberty server configuration directory:
 

--- a/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
+++ b/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Configuration Steps For Hardware Cryptography for Liberty for Linux with Semeru Java 17"
+title: "Configuration Steps For Hardware Cryptography for Liberty for Linux on DISTRIBUTED environment with Semeru Java 17"
 # Do NOT change the categories section
 categories: blog
 author_picture: https://avatars3.githubusercontent.com/htakamiy
 author_github: https://github.ibm.com/htakamiy
-seo-title: Configuration Steps For Hardware Cryptography for Liberty for Linux with Semeru Java 17
-seo-description: The steps necessary to enable hardware cryptography with Liberty for Linux with Semeru Java 17. 
-blog_description: "The steps necessary to enable hardware cryptography with Liberty for Linux with Semeru Java 17. The configuration enables Liberty to leverage hardware security modules for enhanced security in cryptographic operations."
+seo-title: Configuration Steps For Hardware Cryptography for Liberty for Linux on DISTRIBUTED environment with Semeru Java 17
+seo-description: The steps necessary to enable hardware cryptography with Liberty for Linux on DISTRIBUTED environment with Semeru Java 17. 
+blog_description: "The steps necessary to enable hardware cryptography with Liberty for Linux on DISTRIBUTED environment with Semeru Java 17. The configuration enables Liberty to leverage hardware security modules for enhanced security in cryptographic operations."
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
 additional_authors: 
@@ -15,7 +15,7 @@ additional_authors:
   github: https://github.com/RoastedMilkTea
   image: https://avatars0.githubusercontent.com/RoastedMilkTea
 ---
-= Enabling Hardware Cryptography for Liberty for Linux with Semeru Java 17
+= Enabling Hardware Cryptography for Liberty for Linux on DISTRIBUTED environment with Semeru Java 17
 Hiroko Takamiya <https://github.com/htakamiy>
 :imagesdir: /
 :url-prefix:
@@ -61,11 +61,11 @@ Hiroko Takamiya <https://github.com/htakamiy>
 // // // // // // // //
 
 == Summary
-This technote provides configuration steps for integrating Liberty for Linux with hardware cryptographic devices. These steps were successfully tested by a customer using a Thales Luna HSM with Semeru Java 17 and have been shared with their permission. The steps should be applicable for other Java versions as well, with minor adjustments if needed. The configuration should also be adaptable to other hardware security modules that support the PKCS#11 interface.
+This technote provides configuration steps for integrating Liberty for Linux *on DISTRIBUTED environment* with hardware cryptographic devices. These steps were successfully tested by a customer using a Thales Luna HSM with Semeru Java 17 and have been shared with their permission. The steps should be applicable for other Java versions as well, with minor adjustments if needed. The configuration should also be adaptable to other hardware security modules that support the PKCS#11 interface.
 
 == Objective
 
-This document provides the steps necessary to enable hardware cryptography with Liberty for Linux. The configuration enables Liberty to leverage hardware security modules for enhanced security in cryptographic operations.
+This document provides the steps necessary to enable hardware cryptography with Liberty *on DISTRIBUTED environment* for Linux. The configuration enables Liberty to leverage hardware security modules for enhanced security in cryptographic operations.
 
 === Environment
 
@@ -74,7 +74,7 @@ The customer's successful implementation used:
 - Thales Luna HSM
 
 These steps should be applicable for:
-- Liberty for Linux with other Java versions (Java 11, Java 21, etc.)
+- Liberty for Linux *on DISTRIBUTED environment* with other Java versions (Java 11, Java 21, etc.)
 - Other HSMs with PKCS#11 interface support
 
 == Steps
@@ -142,12 +142,12 @@ These steps should be applicable for:
 
  -Djava.security.properties=${server.config.dir}/java.security
 
-. *Create Required Certificates*
+. *For HSM (Hardware-Based Keystore/Truststore)* - Input Required Certificates
 * *General Step:* Create or import the necessary certificates for your application's security requirements.
 
 * *Implementation:* Required application certificates (TLS server certificate and client certificates for various use cases) were created using Java keytool.
 
-. *Create a Traditional Truststore*
+. *For File-Based Keystore/Truststore* - Create a Traditional Truststore
 * *General Step:* Create a standard file-based truststore to hold trusted CA certificates.
 
 * *Implementation:* A traditional PKCS12 file-based keystore was created to serve as the general "truststore" in Liberty, which included CA certificates to be trusted.
@@ -156,6 +156,9 @@ These steps should be applicable for:
 * *General Step:* Configure the Liberty server.xml file to use both the HSM-backed keystore and the file-based truststore.
 
 * *Implementation:* The Liberty server.xml was configured with two keystore elements:
+* Note: These following steps are to demonstrate that both Hardware keystore and the file-based (Software) keystore can be configured in Liberty at the same time.
+** If only configuring *one of the following* (either HSM or File-Based), only copy the appropriate one from below) 
+
 
  <!-- Standard file-based truststore -->
   <keyStore
@@ -233,7 +236,8 @@ While these steps were written and tested with Semeru Java 17, they should be ap
 * Security provider configurations may have slight differences between Java versions
 
 == Acknowledgements
-Special thanks to our customer Peter Vannman for providing these detailed configuration steps and use cases for Liberty integration with Thales Luna HSM, and for allowing us to share this information with the broader Liberty community.
+We would like to sincerely thank a valued customer who, while choosing to remain anonymous, generously shared his expertise with us. Access to this level of specialized hardware and configuration experience is rare. Through collaboration, persistence, and thoughtful experimentation, he helped validate solutions and provided the practical steps documented here.
+His willingness to share these insights will benefit many others in the WAS community facing similar challenges. We deeply appreciate his generosity and the meaningful impact of his contribution.
 // // // // // // // //
 // LINKS
 //s

--- a/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
+++ b/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Configuration Steps For Hardware Cryptography for Liberty for Linux on DISTRIBUTED environment with Semeru Java 17"
+title: "Configuration Steps For Hardware Cryptography for Liberty for Linux on distributed environment with Semeru Java 17"
 # Do NOT change the categories section
 categories: blog
 author_picture: https://avatars3.githubusercontent.com/htakamiy
 author_github: https://github.ibm.com/htakamiy
-seo-title: Configuration Steps For Hardware Cryptography for Liberty for Linux on DISTRIBUTED environment with Semeru Java 17
-seo-description: The steps necessary to enable hardware cryptography with Liberty for Linux on DISTRIBUTED environment with Semeru Java 17. 
-blog_description: "The steps necessary to enable hardware cryptography with Liberty for Linux on DISTRIBUTED environment with Semeru Java 17. The configuration enables Liberty to leverage hardware security modules for enhanced security in cryptographic operations."
+seo-title: Configuration Steps For Hardware Cryptography for Liberty for Linux on distributed environment with Semeru Java 17
+seo-description: The steps necessary to enable hardware cryptography with Liberty for Linux on distributed environment with Semeru Java 17. 
+blog_description: "The steps necessary to enable hardware cryptography with Liberty for Linux on distributed environment with Semeru Java 17. The configuration enables Liberty to leverage hardware security modules for enhanced security in cryptographic operations."
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
 additional_authors: 
@@ -15,7 +15,7 @@ additional_authors:
   github: https://github.com/RoastedMilkTea
   image: https://avatars0.githubusercontent.com/RoastedMilkTea
 ---
-= Enabling Hardware Cryptography for Liberty for Linux on DISTRIBUTED environment with Semeru Java 17
+= Enabling Hardware Cryptography for Liberty for Linux on distributed environment with Semeru Java 17
 Hiroko Takamiya <https://github.com/htakamiy>
 :imagesdir: /
 :url-prefix:

--- a/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
+++ b/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
@@ -61,11 +61,11 @@ Hiroko Takamiya <https://github.com/htakamiy>
 // // // // // // // //
 
 == Summary
-This technote provides configuration steps for integrating Liberty for Linux *on DISTRIBUTED environment* with hardware cryptographic devices. These steps were successfully tested by a customer using a Thales Luna HSM with Semeru Java 17 and have been shared with their permission. The steps should be applicable for other Java versions as well, with minor adjustments if needed. The configuration should also be adaptable to other hardware security modules that support the PKCS#11 interface.
+This technote provides configuration steps for integrating Liberty for Linux on distributed environment with hardware cryptographic devices. These steps were successfully tested by a customer using a Thales Luna HSM with Semeru Java 17 and have been shared with their permission. The steps should be applicable for other Java versions as well, with minor adjustments if needed. The configuration should also be adaptable to other hardware security modules that support the PKCS#11 interface.
 
 == Objective
 
-This document provides the steps necessary to enable hardware cryptography with Liberty *on DISTRIBUTED environment* for Linux. The configuration enables Liberty to leverage hardware security modules for enhanced security in cryptographic operations.
+This document provides the steps necessary to enable hardware cryptography with Liberty *on distributed environment* for Linux. The configuration enables Liberty to leverage hardware security modules for enhanced security in cryptographic operations.
 
 === Environment
 
@@ -74,7 +74,7 @@ The customer's successful implementation used:
 - Thales Luna HSM
 
 These steps should be applicable for:
-- Liberty for Linux *on DISTRIBUTED environment* with other Java versions (Java 11, Java 21, etc.)
+- Liberty for Linux on distributed environment with other Java versions (Java 11, Java 21, etc.)
 - Other HSMs with PKCS#11 interface support
 
 == Steps

--- a/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
+++ b/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Configuration Steps For Hardware Cryptography for Liberty for Linux on distributed environment with Semeru Java 17"
+title: "Enabling hardware cryptography for Liberty for Linux on distributed environment with Semeru Java 17"
 # Do NOT change the categories section
 categories: blog
 author_picture: https://avatars3.githubusercontent.com/htakamiy

--- a/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
+++ b/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
@@ -151,10 +151,8 @@ For example, edit the Liberty `server.env` file with the following configuration
  JAVA_HOME=/etc/alternatives/jre_17
   JVM_ARGS="--add-exports=jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED"
 
-Where:
-* The `--add-exports` JVM argument is necessary because in Java 17, the Java module system restricts access to internal packages. The PKCS#11 implementation requires access to classes in the `sun.security.pkcs11` package, which is part of the `jdk.crypto.cryptoki` module. This argument explicitly allows Liberty to access these internal classes that are needed for the HSM integration to work properly.
-+
-Similar JVM arguments might be required for other Java versions that use the module system (Java 9 and later). The specific arguments might vary slightly depending on the Java version.
+* Where: The `--add-exports` JVM argument is necessary because in Java 17, the Java module system restricts access to internal packages. The PKCS#11 implementation requires access to classes in the `sun.security.pkcs11` package, which is part of the `jdk.crypto.cryptoki` module. This argument explicitly allows Liberty to access these internal classes that are needed for the HSM integration to work properly.
+** Similar JVM arguments might be required for other Java versions that use the module system (Java 9 and later). The specific arguments might vary slightly depending on the Java version.
 
 . Configure any JVM options that are required for your specific HSM compatibility. For example, to disable unsupported algorithms, add the list of algorithms to the Liberty `jvm.options` file:
 
@@ -175,6 +173,15 @@ While these steps were written and tested with Semeru Java 17, they should be ap
 * The module-related JVM arguments (`--add-exports`) may vary depending on the Java version
 * The exact path to the Java installation will differ
 * Security provider configurations may have slight differences between Java versions
+
+== Related Articles
+Server configuration overview:  link:https://openliberty.io/docs/latest/reference/config/server-configuration-overview.html[]
+
+Feature Overview: link:https://openliberty.io/docs/latest/reference/feature/feature-overview.html[]
+
+Enabling hardware cryptography for Liberty for z/OS using Java 11, Java 17, or Java 21: link:https://www.ibm.com/support/pages/enabling-hardware-cryptography-liberty-zos-using-java-11-java-17-or-java-21?view=full[]
+
+
 
 == Acknowledgements
 We would like to sincerely thank a valued customer who, while choosing to remain anonymous, generously shared his expertise with us. Access to this level of specialized hardware and configuration experience is rare. Through collaboration, persistence, and thoughtful experimentation, he helped validate solutions and provided the practical steps documented here.

--- a/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
+++ b/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
@@ -78,17 +78,13 @@ These steps should be applicable for:
 - Other HSMs with PKCS#11 interface support
 
 == Steps
-. *Install HSM Client Libraries*
-* *General Step:* Install the client libraries that enable communication between your application and the HSM.
-* *Implementation:* The Luna client libraries were installed on the Linux server using installation packages provided by Thales.
+. Install *HSM client libraries* that enable communication between your application and the HSM.
 
-. *Configure Authentication Between Client and HSM*
-  * *General Step:* Configure authentication between the Linux server and the HSM to establish secure communication.
-  * *Implementation:* Authentication was configured using commands provided with the Luna client installation. A self-signed client certificate was created and registered with the Luna HSM, establishing mutual TLS as the authentication method.
+. Configure authentication between the Linux server and the HSM to establish secure communication.
+A self-signed client certificate should have been created and registered, establishing mutual TLS as the authentication method.
 
-. *Create a PKCS#11 Configuration File*
-* *General Step:* Create a configuration file that defines how Java will interact with the HSM through the PKCS#11 interface.
-* *Implementation:* The following PKCS11Config.cfg file was created with assistance from Luna Support and saved in the Liberty server configuration directory:
+. *Create a PKCS#11 configuration file* that defines how Java will interact with the HSM through the PKCS#11 interface.
+* The following PKCS11Config.cfg file should have been created with assistance from Luna Support and saved in the Liberty server configuration directory:
 
  description = Thales Luna HSM/PKCS11 Configuration
   name = PKCS11Config
@@ -121,9 +117,8 @@ These steps should be applicable for:
   CKA_WRAP=true
   }
   
-. *Update Java Security Configuration*
-* *General Step:* Update the Java security configuration to include the PKCS#11 provider.
-* *Implementation:* A java.security file was created in the same directory as the server.xml with the following content to add the SunPKCS11 provider pointing to the PKCS11Config.cfg file:
+. Update the *Java security configuration* to include the PKCS#11 provider.
+* A java.security file should have been created in the same directory as the server.xml with the following content to add the SunPKCS11 provider pointing to the PKCS11Config.cfg file:
 
   security.provider.1=SunPKCS11 ${server.config.dir}/PKCS11Config.cfg
   security.provider.2=SUN
@@ -143,20 +138,14 @@ These steps should be applicable for:
  -Djava.security.properties=${server.config.dir}/java.security
 
 . *For HSM (Hardware-Based Keystore/Truststore)* - Input Required Certificates
-* *General Step:* Create or import the necessary certificates for your application's security requirements.
-
-* *Implementation:* Required application certificates (TLS server certificate and client certificates for various use cases) were created using Java keytool.
+* Create or import the necessary certificates for your application's security requirements. (i.e. TLS server certificate and client certificates for various use cases)
 
 . *For File-Based Keystore/Truststore* - Create a Traditional Truststore
-* *General Step:* Create a standard file-based truststore to hold trusted CA certificates.
+* Create a standard file-based truststore to hold trusted CA certificates.
+** A traditional PKCS12 file-based keystore was created to serve as the general "truststore" in Liberty, which included CA certificates to be trusted.
 
-* *Implementation:* A traditional PKCS12 file-based keystore was created to serve as the general "truststore" in Liberty, which included CA certificates to be trusted.
-
-. *Configure Liberty Server.xml*
-* *General Step:* Configure the Liberty server.xml file to use both the HSM-backed keystore and the file-based truststore.
-
-* *Implementation:* The Liberty server.xml was configured with two keystore elements:
-* Note: These following steps are to demonstrate that both Hardware keystore and the file-based (Software) keystore can be configured in Liberty at the same time.
+. Configure the *Liberty server.xml file to use both* the HSM-backed keystore and the file-based truststore.
+* *Note*: These following steps are to demonstrate that both Hardware keystore and the file-based (Software) keystore can be configured in Liberty at the same time.
 ** If only configuring *one of the following* (either HSM or File-Based), only copy the appropriate one from below) 
 
 
@@ -185,28 +174,26 @@ These steps should be applicable for:
 
 . *Configure Server Environment*
 
-* *General Step:* Set up the necessary environment variables for the Liberty server.
+* Set up the necessary environment variables for the Liberty server.
 
-* *Implementation:* The following properties were set in the Liberty server.env file:
+* The following properties were set in the Liberty server.env file:
 
  JAVA_HOME=/etc/alternatives/jre_17
   JVM_ARGS="--add-exports=jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED"
 
 * The --add-exports JVM argument is necessary because in Java 17, the Java module system restricts access to internal packages. The PKCS#11 implementation requires access to classes in the sun.security.pkcs11 package, which is part of the jdk.crypto.cryptoki module. This argument explicitly allows Liberty to access these internal classes that are needed for the HSM integration to work properly.
 
-* Note: Similar JVM arguments may be required for other Java versions that use the module system (Java 9 and later). The specific arguments might vary slightly depending on the Java version.
+* *Note:* Similar JVM arguments may be required for other Java versions that use the module system (Java 9 and later). The specific arguments might vary slightly depending on the Java version.
 
 . *Configure JVM Options (if needed)*
-* *General Step:* Configure any JVM options required for your specific HSM compatibility.
+* *Configure any JVM options required for your specific HSM compatibility.
 
-* *Implementation:* The following settings were added to Liberty jvm.options to disable unsupported algorithms:
+** The following settings were added to Liberty jvm.options to disable unsupported algorithms:
 
  -Djdk.tls.disabledAlgorithms=RSASSA-PSS,RSAPSS
 
 . *Start Liberty Server and Verify Configuration*
-* *General Step:* Start your Liberty server and verify that the HSM integration is working correctly.
-
-* *Implementation:* After completing the above steps, the Liberty integration worked successfully with the Luna HSM.
+* * Start your Liberty server and verify that the HSM integration is working correctly. 
 
 == Sample Use Cases
 The HSM integration with Liberty enables enhanced security for various cryptographic operations. Here are some sample use cases:

--- a/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
+++ b/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
@@ -25,23 +25,6 @@ Hiroko Takamiya <https://github.com/htakamiy>
 :url-about: /
 //Blank line here is necessary before starting the body of the post.
 
-
-== Summary
-This technote provides configuration steps for integrating Liberty for Linux on distributed environment with hardware cryptographic devices. These steps were successfully tested by a customer using a Thales Luna HSM with Semeru Java 17 and have been shared with their permission. The steps should be applicable for other Java versions as well, with minor adjustments if needed. The configuration should also be adaptable to other hardware security modules that support the PKCS#11 interface.
-
-== Objective
-
-This document provides the steps necessary to enable hardware cryptography with Liberty *on distributed environment* for Linux. The configuration enables Liberty to leverage hardware security modules for enhanced security in cryptographic operations.
-
-=== Environment
-
-The customer's successful implementation used:
-- Liberty for Linux with IBM Semeru Runtime Certified Edition for Linux Version 17 (Java 17)
-- Thales Luna HSM
-
-These steps should be applicable for:
-- Liberty for Linux on distributed environment with other Java versions (Java 11, Java 21, etc.)
-
 Hardware cryptography, through hardware security modules (HSM), provides enhanced security for applications that are running on Liberty on distributed Linux environments. The following instructions to integrate Liberty on distributed Linux with hardware cryptographic devices were successfully tested by a customer who was using a Thales Luna HSM with Semeru Java 17. These instructions should also be applicable to other Java versions; see <<Java version considerations>> for potential modifications needed. The configuration should be adaptable to other hardware security modules that support the PKCS#11 interface.
 
 ## Example use cases 

--- a/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
+++ b/posts/2026-05-11-configuration-steps-for-hardware-cryptography-for-liberty-for-linux.adoc
@@ -5,9 +5,9 @@ title: "Enabling hardware cryptography for Liberty for Linux on distributed envi
 categories: blog
 author_picture: https://avatars3.githubusercontent.com/htakamiy
 author_github: https://github.ibm.com/htakamiy
-seo-title: Configuration Steps For Hardware Cryptography for Liberty for Linux on distributed environment with Semeru Java 17
-seo-description: The steps necessary to enable hardware cryptography with Liberty for Linux on distributed environment with Semeru Java 17. 
-blog_description: "The steps necessary to enable hardware cryptography with Liberty for Linux on distributed environment with Semeru Java 17. The configuration enables Liberty to leverage hardware security modules for enhanced security in cryptographic operations."
+seo-title: Enabling hardware cryptography for Liberty for Linux on distributed environment with Semeru Java 17
+seo-description: Enabling hardware cryptography for Liberty for Linux on distributed environment with Semeru Java 17. The configuration integrates Liberty with hardware security modules (HSM) for enhanced security.
+blog_description: "Enabling hardware cryptography for Liberty for Linux on distributed environment with Semeru Java 17. The configuration integrates Liberty with hardware security modules (HSM) for enhanced security."
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
 additional_authors: 
@@ -15,50 +15,13 @@ additional_authors:
   github: https://github.com/RoastedMilkTea
   image: https://avatars0.githubusercontent.com/RoastedMilkTea
 ---
-= Enabling Hardware Cryptography for Liberty for Linux on distributed environment with Semeru Java 17
+= Enabling hardware cryptography for Liberty for Linux on distributed environment with Semeru Java 17
 Hiroko Takamiya <https://github.com/htakamiy>
 :imagesdir: /
 :url-prefix:
 :url-about: /
 //Blank line here is necessary before starting the body of the post.
 
-// // // // // // // //
-// In the preceding section:
-// Do not insert any blank lines between any of the lines.
-//
-// "open-graph-image" is set to OL logo. Whenever possible update this to a more appropriate/specific image (for example if present an image that is being used in the post). 
-// However, it can be left empty which will set it to the default
-//
-// "open-graph-image-alt" is a description of what is in the image (not a caption). When changing "open-graph-image" to
-// a custom picture, you must provide a custom string for "open-graph-image-alt".
-//
-// Replace TITLE with the blog post title
-//
-// Replace SECOND_AUTHOR_NAME with the name of the second author.
-// Replace SECOND_GITHUB_USERNAME with the GitHub user name of the second author.
-// Replace THIRD_AUTHOR_NAME with the name of the third author. And so on for fourth, fifth, etc authors.
-// Replace THIRD_GITHUB_USERNAME with the GitHub user name of the third author. And so on for fourth, fifth, etc authors.
-//
-// Replace AUTHOR_NAME with your name as first author.
-// Replace GITHUB_USERNAME with your GitHub username eg: lauracowen
-// Replace DESCRIPTION with a short summary (~60 words) of the release (a more succinct version of the first paragraph of the post).
-//
-// Replace AUTHOR_NAME with your name as you'd like it to be displayed, eg: Laura Cowen
-//
-// Example post: 2020-02-12-faster-startup-Java-applications-criu.adoc
-//
-// If adding image into the post add :
-// -------------------------
-// [.img_border_light]
-// image::img/blog/FILE_NAME[IMAGE CAPTION ,width=70%,align="center"]
-// -------------------------
-// "[.img_border_light]" = This adds a faint grey border around the image to make its edges sharper. Use it around
-// screenshots but not around diagrams. Then double check how it looks.
-// There is also a "[.img_border_dark]" class which tends to work best with screenshots that are taken on dark backgrounds.
-// Once again make sure to double check how it looks
-// Change "FILE_NAME" to the name of the image file. Also make sure to put the image into the right folder which is: img/blog
-// change the "IMAGE CAPTION" to a couple words of what the image is
-// // // // // // // //
 
 == Summary
 This technote provides configuration steps for integrating Liberty for Linux on distributed environment with hardware cryptographic devices. These steps were successfully tested by a customer using a Thales Luna HSM with Semeru Java 17 and have been shared with their permission. The steps should be applicable for other Java versions as well, with minor adjustments if needed. The configuration should also be adaptable to other hardware security modules that support the PKCS#11 interface.
@@ -75,16 +38,27 @@ The customer's successful implementation used:
 
 These steps should be applicable for:
 - Liberty for Linux on distributed environment with other Java versions (Java 11, Java 21, etc.)
-- Other HSMs with PKCS#11 interface support
+Hardware cryptography, through hardware security modules (HSM), provides enhanced security for applications that are running on Liberty on distributed Linux environments. The following instructions to integrate Liberty on distributed Linux with hardware cryptographic devices were successfully tested by a customer who was using a Thales Luna HSM with Semeru Java 17. These instructions should also be applicable to other Java versions; see <<Java version considerations>> for potential modifications needed. The configuration should be adaptable to other hardware security modules that support the PKCS#11 interface.
+
+## Example use cases 
+
+The HSM integration with Liberty enables enhanced security for various cryptographic operations. Here are some example use cases: 
+
+- **Secure Web Services with HSM-Protected Keys**: Liberty serves as a secure web service endpoint using TLS with the server’s private key stored in the HSM. The TLS handshake uses the HSM-protected key, ensuring the private key never leaves the secure hardware boundary, even if the Liberty server is compromised.   
+- **Mutual TLS Authentication for Microservices**: Liberty stores client certificates in the HSM for outbound connections requiring mutual TLS. The HSM handles the cryptographic operations for client authentication, protecting the private key material.
+- **Digital Signature Services**: Applications can use the HSM to sign data (like JSON Web Tokens) with keys that are generated and stored within the HSM. The signing operation occurs inside the hardware, maintaining the integrity of the signing process. 
+- **Secure Data Encryption and Decryption**: Encryption keys are securely stored in the HSM, and encryption/decryption operations are performed by the hardware, providing an additional layer of security for sensitive data.
+- **Certificate Authority Operations**: Organizations running their own CA can store root and intermediate certificate private keys in the HSM, with certificate signing operations performed within the hardware to ensure the highest level of protection for these critical security assets. 
 
 == Steps
 . Install *HSM client libraries* that enable communication between your application and the HSM.
 
 . Configure authentication between the Linux server and the HSM to establish secure communication.
-A self-signed client certificate should have been created and registered, establishing mutual TLS as the authentication method.
+Create and register a self-signed client certificate, establishing mutual TLS as the authentication method.
 
 . *Create a PKCS#11 configuration file* that defines how Java will interact with the HSM through the PKCS#11 interface.
-* The following PKCS11Config.cfg file should have been created with assistance from Luna Support and saved in the Liberty server configuration directory:
++
+For example, the following PKCS11Config.cfg file was created with assistance from Luna Support and saved in the Liberty server configuration directory:
 
  description = Thales Luna HSM/PKCS11 Configuration
   name = PKCS11Config
@@ -117,8 +91,9 @@ A self-signed client certificate should have been created and registered, establ
   CKA_WRAP=true
   }
   
-. Update the *Java security configuration* to include the PKCS#11 provider.
-* A java.security file should have been created in the same directory as the server.xml with the following content to add the SunPKCS11 provider pointing to the PKCS11Config.cfg file:
+. Update the Java security configuration to include the PKCS#11 provider. +
++
+For example, create a `java.security` file in the same directory as the `server.xml` file with the following content to add the SunPKCS11 provider pointing to the `PKCS11Config.cfg` file:
 
   security.provider.1=SunPKCS11 ${server.config.dir}/PKCS11Config.cfg
   security.provider.2=SUN
@@ -133,20 +108,16 @@ A self-signed client certificate should have been created and registered, establ
   security.provider.11=JdkLDAP
   security.provider.12=JdkSASL
 
-* Additionally, a jvm.options file was created in the same directory with the following content to point to the custom java.security file:
++
+Also create, a `jvm.options` file in the same directory with the following content to point to the custom `java.security` file:
 
  -Djava.security.properties=${server.config.dir}/java.security
 
-. *For HSM (Hardware-Based Keystore/Truststore)* - Input Required Certificates
-* Create or import the necessary certificates for your application's security requirements. (i.e. TLS server certificate and client certificates for various use cases)
+. Set up a hardware-based keystore/truststore, a file-based keystore/truststore, or both:
+* For a HSM (hardware-based keystore/truststore), create or import the necessary certificates for your application's security requirements. (i.e. TLS server certificate and client certificates for various use cases).
+* For a file-based keystore/truststore, create a standard file-based truststore to hold trusted CA certificates. For example, a traditional PKCS12 file-based keystore can be created to serve as the general "truststore" in Liberty, which includes the CA certificates to be trusted.
 
-. *For File-Based Keystore/Truststore* - Create a Traditional Truststore
-* Create a standard file-based truststore to hold trusted CA certificates.
-** A traditional PKCS12 file-based keystore was created to serve as the general "truststore" in Liberty, which included CA certificates to be trusted.
-
-. Configure the *Liberty server.xml file to use both* the HSM-backed keystore and the file-based truststore.
-* *Note*: These following steps are to demonstrate that both Hardware keystore and the file-based (Software) keystore can be configured in Liberty at the same time.
-** If only configuring *one of the following* (either HSM or File-Based), only copy the appropriate one from below) 
+. Edit the Liberty `server.xml` file to use the HSM-backed keystore, the file-based truststore, or both by adding the relevant configuration snippets:
 
 
  <!-- Standard file-based truststore -->
@@ -172,41 +143,24 @@ A self-signed client certificate should have been created and registered, establ
   <!-- or -->
   <feature>ssl-1.0</feature>
 
-. *Configure Server Environment*
+. Configure the  Liberty server environment variables.
++
 
-* Set up the necessary environment variables for the Liberty server.
-
-* The following properties were set in the Liberty server.env file:
+For example, edit the Liberty `server.env` file with the following configuration:
 
  JAVA_HOME=/etc/alternatives/jre_17
   JVM_ARGS="--add-exports=jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED"
 
-* The --add-exports JVM argument is necessary because in Java 17, the Java module system restricts access to internal packages. The PKCS#11 implementation requires access to classes in the sun.security.pkcs11 package, which is part of the jdk.crypto.cryptoki module. This argument explicitly allows Liberty to access these internal classes that are needed for the HSM integration to work properly.
+Where:
+* The `--add-exports` JVM argument is necessary because in Java 17, the Java module system restricts access to internal packages. The PKCS#11 implementation requires access to classes in the `sun.security.pkcs11` package, which is part of the `jdk.crypto.cryptoki` module. This argument explicitly allows Liberty to access these internal classes that are needed for the HSM integration to work properly.
++
+Similar JVM arguments might be required for other Java versions that use the module system (Java 9 and later). The specific arguments might vary slightly depending on the Java version.
 
-* *Note:* Similar JVM arguments may be required for other Java versions that use the module system (Java 9 and later). The specific arguments might vary slightly depending on the Java version.
-
-. *Configure JVM Options (if needed)*
-* *Configure any JVM options required for your specific HSM compatibility.
-
-** The following settings were added to Liberty jvm.options to disable unsupported algorithms:
+. Configure any JVM options that are required for your specific HSM compatibility. For example, to disable unsupported algorithms, add the list of algorithms to the Liberty `jvm.options` file:
 
  -Djdk.tls.disabledAlgorithms=RSASSA-PSS,RSAPSS
 
-. *Start Liberty Server and Verify Configuration*
-* * Start your Liberty server and verify that the HSM integration is working correctly. 
-
-== Sample Use Cases
-The HSM integration with Liberty enables enhanced security for various cryptographic operations. Here are some sample use cases:
-
-* *Secure Web Services with HSM-Protected Keys:* Liberty serves as a secure web service endpoint using TLS with the server's private key stored in the HSM. The TLS handshake uses the HSM-protected key, ensuring the private key never leaves the secure hardware boundary, even if the Liberty server is compromised.
-
-* *Mutual TLS Authentication for Microservices:* Liberty stores client certificates in the HSM for outbound connections requiring mutual TLS. The HSM handles the cryptographic operations for client authentication, protecting the private key material.
-
-* *Digital Signature Services:* Applications can use the HSM to sign data (like JSON Web Tokens) with keys that are generated and stored within the HSM. The signing operation occurs inside the hardware, maintaining the integrity of the signing process.
-
-* *Secure Data Encryption and Decryption:* Encryption keys are securely stored in the HSM, and encryption/decryption operations are performed by the hardware, providing an additional layer of security for sensitive data.
-
-* *Certificate Authority Operations:* Organizations running their own CA can store root and intermediate certificate private keys in the HSM, with certificate signing operations performed within the hardware to ensure the highest level of protection for these critical security assets.
+. Start the Liberty server and verify that the HSM integration is working correctly.
 
 == Troubleshooting
 If you encounter issues with your HSM integration, consider enabling PKCS#11 debug logging by adding to jvm.options:
@@ -215,7 +169,7 @@ If you encounter issues with your HSM integration, consider enabling PKCS#11 deb
 
 For specific HSM-related issues, consult your HSM vendor's documentation and support resources.
 
-== Java Version Considerations
+== Java version considerations
 While these steps were written and tested with Semeru Java 17, they should be applicable to other Java versions with potential minor adjustments:
 
 * The module-related JVM arguments (`--add-exports`) may vary depending on the Java version


### PR DESCRIPTION
This PR adds a new blog post about configuring hardware cryptography for Liberty on Linux.