### PR TITLE
fix: Japanese 26.0.0.5 blog post double quotes

### DIFF
--- a/posts/ja/2026-05-19-26.0.0.5.adoc
+++ b/posts/ja/2026-05-19-26.0.0.5.adoc
@@ -327,7 +327,7 @@ Liberty の `securityLevel` ベースの暗号カテゴリは、もはや意味�
 
 [source,xml]
 ----
-<ssl id="defaultSSL" securityLevel=HIGH/>
+<ssl id="defaultSSL" securityLevel="HIGH"/>
 ----
 
 `securityLevel` 属性は無視されるようになったため、前の `<ssl>` 構成は、`securityLevel` 属性が構成されていない次の構成と同等に扱われます。


### PR DESCRIPTION
Related to https://github.com/OpenLiberty/blogs/pull/4995