### PR TITLE
Update production - Fix missing double quotes in 26.0.0.5 blog posts

### DIFF
--- a/posts/2026-05-05-26.0.0.5-beta.adoc
+++ b/posts/2026-05-05-26.0.0.5-beta.adoc
@@ -161,7 +161,7 @@ The `enabledCiphers` attribute now has two mutually exclusive modes: (1) Specify
 
 [source,xml]
 ----
-<ssl id="defaultSSL" securityLevel=HIGH/>
+<ssl id="defaultSSL" securityLevel="HIGH"/>
 ----
 
 The `securityLevel` attribute is now ignored, so the previous `<ssl>` configuration is treated equivalently to the configuration shown here where there is no `securityLevel` attribute configured.

--- a/posts/2026-05-19-26.0.0.5.adoc
+++ b/posts/2026-05-19-26.0.0.5.adoc
@@ -320,7 +320,7 @@ The `enabledCiphers` attribute now has two mutually exclusive modes: (1) Specify
 
 [source,xml]
 ----
-<ssl id="defaultSSL" securityLevel=HIGH/>
+<ssl id="defaultSSL" securityLevel="HIGH"/>
 ----
 
 The `securityLevel` attribute is now ignored, so the previous `<ssl>` configuration is treated equivalently to the configuration shown here where there is no `securityLevel` attribute configured.


### PR DESCRIPTION
Tested on blog-staging

- https://blogs-staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/blog/2026/05/05/26.0.0.5-beta.html
<img width="3456" height="1872" alt="image" src="https://github.com/user-attachments/assets/88d6f3c7-b583-4a2d-807e-4bd506823081" />


- https://blogs-staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/blog/2026/05/19/26.0.0.5.html

<img width="3456" height="1790" alt="image" src="https://github.com/user-attachments/assets/d1b25d22-2a62-4f12-b84f-705761a41d81" />
