### PR TITLE
Update Prod

### DIFF
--- a/blog_tags.json
+++ b/blog_tags.json
@@ -732,7 +732,7 @@
         },
                 {
             "name": "ai",
-            "posts": ["26.0.0.9","26.0.0.9-beta","26.0.0.8-beta",
+            "posts": ["mcp-tools","26.0.0.9","26.0.0.9-beta","26.0.0.8-beta",
                      "liberty-langchain4j-workshop","open-liberty-with-langchain4j-rag",
                       "26.0.0.3-beta","26.0.0.2-beta",
                       "26.0.0.1-beta","langchain4j-jakartaee-streaming",

--- a/blog_tags.json
+++ b/blog_tags.json
@@ -2,7 +2,7 @@
     "blog_tags": [
         {
             "name": "announcements",
-            "posts": ["26.0.0.9-beta",
+            "posts": ["26.0.0.9","26.0.0.9-beta",
                     "26.0.0.8","26.0.0.8-beta",
                     "26.0.0.7", "26.0.0.7-beta", 
                       "26.0.0.6", "26.0.0.6-beta", 
@@ -205,7 +205,7 @@
         },
         {
             "name": "release",
-            "posts": ["26.0.0.9-beta",
+            "posts": ["26.0.0.9","26.0.0.9-beta",
                     "26.0.0.8","26.0.0.8-beta",
                     "26.0.0.7", "26.0.0.7-beta", 
                       "26.0.0.6", "26.0.0.6-beta", 
@@ -732,7 +732,7 @@
         },
                 {
             "name": "ai",
-            "posts": ["26.0.0.9-beta","26.0.0.8-beta",
+            "posts": ["26.0.0.9","26.0.0.9-beta","26.0.0.8-beta",
                      "liberty-langchain4j-workshop","open-liberty-with-langchain4j-rag",
                       "26.0.0.3-beta","26.0.0.2-beta",
                       "26.0.0.1-beta","langchain4j-jakartaee-streaming",

--- a/posts/2026-08-25-mcp-tools.adoc
+++ b/posts/2026-08-25-mcp-tools.adoc
@@ -6,7 +6,7 @@ author_picture: https://avatars3.githubusercontent.com/TheoGkoumas
 author_github: https://github.com/TheoGkoumas
 seo-title: Support for the Model Context Protocol within Open Liberty - OpenLiberty.io
 seo-description: Learn how to use the MCP Server feature within your Liberty application to allow your business logic to be utilized within an agentic AI workflow.
-blog_description: Learn how to use the MCP Server feature within your Liberty application to allow your business logic to be utilized within an agentic AI workflow.
+blog_description: "Learn how to use the MCP Server feature within your Liberty application to allow your business logic to be utilized within an agentic AI workflow."
 open-graph-image: https://openliberty.io/img/twitter_card.jpg
 open-graph-image-alt: Open Liberty Logo
 ---
@@ -20,7 +20,7 @@ Theo Gkoumas <https://github.com/TheoGkoumas>
 
 == What is MCP?
 
-https://modelcontextprotocol.io/[Model Context Protocol (MCP)] is an open standard that enables AI applications to interact with and utilise external systems. The `mcpServer-1.0` feature for Open Liberty allows developers to expose the business logic of their applications, making it discoverable, understandable, and invocable by AI applications.
+https://modelcontextprotocol.io/[Model Context Protocol (MCP)] is an open standard that enables AI applications to interact with and utilise external systems. The `mcp-1.0` feature for Open Liberty allows developers to expose the business logic of their applications, making it discoverable, understandable, and invocable by AI applications.
 
 == The power of MCP
 
@@ -28,7 +28,7 @@ MCP has emerged as the standard for AI applications to access real-time informat
 
 Consider a scenario where your company provides weather forecasting services that require continuous updates from multiple data sources. Live or frequently changing data can't be included in the training of the model directly, instead we can let the AI retrieve this live data directly, through *tools* - functions the AI can invoke at will to retrieve up-to-date information whenever it needs it.
 
-This is exactly what the Liberty `mcpServer-1.0` feature enables. Your existing Java application already contains the business logic that an AI agent needs: it fetches data, performs calculations, writes to databases, and calls external services. With `mcpServer-1.0`, you can expose that logic to any MCP-compatible AI agent with a few annotations.
+This is exactly what the Liberty `mcp-1.0` feature enables. Your existing Java application already contains the business logic that an AI agent needs: it fetches data, performs calculations, writes to databases, and calls external services. With `mcp-1.0`, you can expose that logic to any MCP-compatible AI agent with a few annotations.
 
 A plain Java method like this:
 
@@ -58,7 +58,7 @@ The AI agent reads the descriptions to understand what the tool does and what va
 
 === Add the MCP API dependency
 
-The `mcpServer-1.0` feature uses the https://github.com/mcp-java/java-mcp-annotations[`mcp-java` API] (`org.mcpjava:mcp-server-api`), which is available on Maven Central.
+The `mcp-1.0` feature uses the https://github.com/mcp-java/java-mcp-annotations[`mcp-java` API] (`org.mcpjava:mcp-server-api`), which is available on Maven Central.
 
 Add the following dependency to your `pom.xml`:
 
@@ -73,48 +73,35 @@ Add the following dependency to your `pom.xml`:
 </dependency>
 ----
 
-Some features - such as `@Schema`, `DefaultValueConverter`, `ToolManager`, and `ToolResponseEncoder` - are provided by the `io.openliberty.mcp` jar that ships with Liberty. To make these available on the build path, you need to add a `system`-scoped dependency in your `pom.xml` that points to this jar.
-
-First, locate the `io.openliberty.mcp_*.jar` in `<wlp>/dev/api/ibm/` and note the version suffix (e.g. `1.0.106`). Then define the following properties in your `pom.xml`:
+Some features - such as `@Schema`, `DefaultValueConverter`, `ToolManager`, and `ToolResponseEncoder` - are provided by the Liberty MCP API, available on Maven Central. Add it as a `provided`-scoped dependency in your `pom.xml`:
 
 [source,xml]
 ----
-<properties>
-    <wlp-dir-path>replace-with-path-to-wlp-dir</wlp-dir-path>
-    <mcp-jar-version>replace-with-version-number</mcp-jar-version>
-</properties>
-----
-
-Then add the dependency:
-
-[source,xml]
-----
-<!-- Liberty MCP extensions (io.openliberty.mcp) -->
+<!-- Liberty MCP API -->
 <dependency>
-    <groupId>io.openliberty.mcp</groupId>
-    <artifactId>mcp-core</artifactId>
-    <version>${mcp-jar-version}</version>
-    <scope>system</scope>
-    <systemPath>${wlp-dir-path}/dev/api/ibm/io.openliberty.mcp_${mcp-jar-version}.jar</systemPath>
+    <groupId>io.openliberty</groupId>
+    <artifactId>io.openliberty.mcp</artifactId>
+    <version>1.2.117</version>
+    <scope>provided</scope>
 </dependency>
 ----
 
 === Enable the feature
 
-Add `mcpServer-1.0` to your `server.xml`:
+Add `mcp-1.0` to your `server.xml`:
 
 [source,xml]
 ----
 <featureManager>
     <feature>servlet-6.0</feature>
     <feature>cdi-4.0</feature>
-    <feature>mcpServer-1.0</feature>
+    <feature>mcp-1.0</feature>
 </featureManager>
 ----
 
 === Find your MCP endpoint URL
 
-Once your application is deployed, the `mcpServer-1.0` feature logs the full MCP endpoint URL in your Liberty messages log:
+Once your application is deployed, the `mcp-1.0` feature logs the full MCP endpoint URL in your Liberty messages log:
 
 [source]
 ----
@@ -219,6 +206,7 @@ A parameter is treated as optional if `required = false`, `defaultValue` is set,
 
 [source,java]
 ----
+import java.util.Optional;
 import org.mcpjava.server.tools.Tool;
 import org.mcpjava.server.tools.ToolArg;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -458,7 +446,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 @ApplicationScoped
 public class RemoteTools {
 
-    @javax.annotation.Resource
+    @jakarta.annotation.Resource
     ManagedExecutorService executor;
 
     @Tool(name = "fetchRemoteData",
@@ -597,7 +585,7 @@ During MCP initialisation, the server sends a `serverInfo` block to clients cont
 
 === Stateless mode
 
-By default, `mcpServer-1.0` maintains sessions to associate requests from the same client. In horizontally scaled or clustered deployments where requests may be routed to different server instances, enable stateless mode to remove this session affinity:
+By default, `mcp-1.0` maintains sessions to associate requests from the same client. In horizontally scaled or clustered deployments where requests may be routed to different server instances, enable stateless mode to remove this session affinity:
 
 [source,xml]
 ----
@@ -606,7 +594,7 @@ By default, `mcpServer-1.0` maintains sessions to associate requests from the sa
 </application>
 ----
 
-In stateless mode, each request is handled independently with no per-client state between calls. However, the stateless mode also disables MCP features that rely on session tracking or linking separate HTTP requests together, such as canceling a tool call.
+In stateless mode, each request is handled independently with no per-client state between calls. However, the stateless mode also disables MCP features that rely on session tracking or linking separate HTTP requests together, such as cancelling a tool call.
 
 === Async tool timeout
 
@@ -621,7 +609,7 @@ By default, asynchronous tool executions are limited to **30 seconds**. For tool
 
 == Supported MCP protocol versions
 
-The `mcpServer-1.0` feature supports the following specification versions, negotiated automatically with the client at connection time:
+The `mcp-1.0` feature supports the following specification versions, negotiated automatically with the client at connection time:
 
 * https://modelcontextprotocol.io/specification/2025-11-25[`2025-11-25`]
 * https://modelcontextprotocol.io/specification/2025-06-18[`2025-06-18`]
@@ -629,16 +617,16 @@ The `mcpServer-1.0` feature supports the following specification versions, negot
 
 == Monitoring MCP server metrics
 
-The `mcpServer-1.0` feature exports operational metrics that let you monitor tool call throughput, duration, and session lifecycle using Liberty's existing observability stack.
+The `mcp-1.0` feature exports operational metrics that let you monitor tool call throughput, duration, and session lifecycle using Liberty's existing observability stack.
 
-Add `monitor-1.0` alongside `mcpServer-1.0` in your `server.xml`. Optionally, add `mpTelemetry-2.1` to export metrics to an OpenTelemetry collector:
+Add `monitor-1.0` alongside `mcp-1.0` in your `server.xml`. Optionally, add `mpTelemetry-2.1` to export metrics to an OpenTelemetry collector:
 
 [source,xml]
 ----
 <featureManager>
     <feature>servlet-6.0</feature>
     <feature>cdi-4.0</feature>
-    <feature>mcpServer-1.0</feature>
+    <feature>mcp-1.0</feature>
     <feature>monitor-1.0</feature>
     <!-- Optional: export to OpenTelemetry -->
     <feature>mpTelemetry-2.1</feature>
@@ -676,6 +664,6 @@ Each module also logs its own `CWMCM0008I` message at startup, so you can find e
 
 == Feedback and more information
 
-We are actively developing the `mcpServer-1.0` feature toward its General Availability release. If you encounter a bug or want to request additional functionality, https://github.com/OpenLiberty/open-liberty/issues/new/choose[raise an issue in the Open Liberty GitHub repository].
+If you encounter a bug or want to request additional functionality, https://github.com/OpenLiberty/open-liberty/issues/new/choose[raise an issue in the Open Liberty GitHub repository].
 
 For more information about the Model Context Protocol, see the https://modelcontextprotocol.io[official MCP documentation].

--- a/posts/2026-08-25-mcp-tools.adoc
+++ b/posts/2026-08-25-mcp-tools.adoc
@@ -79,9 +79,9 @@ Some features - such as `@Schema`, `DefaultValueConverter`, `ToolManager`, and `
 ----
 <!-- Liberty MCP API -->
 <dependency>
-    <groupId>io.openliberty</groupId>
+    <groupId>io.openliberty.api</groupId>
     <artifactId>io.openliberty.mcp</artifactId>
-    <version>1.2.117</version>
+    <version>1.0.117</version>
     <scope>provided</scope>
 </dependency>
 ----

--- a/posts/2026-09-08-26.0.0.9.adoc
+++ b/posts/2026-09-08-26.0.0.9.adoc
@@ -1,0 +1,367 @@
+---
+layout: post
+title: "MCP Server (mcp-1.0), Protected Resource Metadata for openidConnectClient, and more in 26.0.0.9"
+# Do NOT change the categories section
+categories: blog
+author_picture: https://avatars3.githubusercontent.com/IsmathBadsha
+author_github: https://github.com/IsmathBadsha
+seo-title: MCP Server (mcp-1.0), Protected Resource Metadata for openidConnectClient, and more in 26.0.0.9 - OpenLiberty.io
+seo-description: Open Liberty 26.0.0.9 introduces MCP Server support (mcp-1.0), adds OAuth 2.0 Protected Resource Metadata support for openidConnectClient, and introduces custom session cache name prefixes for shared JCache clusters.
+blog_description: Open Liberty 26.0.0.9 introduces MCP Server support (mcp-1.0), adds OAuth 2.0 Protected Resource Metadata support for openidConnectClient, and introduces custom session cache name prefixes for shared JCache clusters.
+open-graph-image: https://openliberty.io/img/twitter_card.jpg
+open-graph-image-alt: Open Liberty Logo
+---
+= MCP Server (mcp-1.0), Protected Resource Metadata for openidConnectClient, and more in 26.0.0.9
+Ismath Badsha <https://github.com/IsmathBadsha>
+:imagesdir: /
+:url-prefix:
+:url-about: /
+//Blank line here is necessary before starting the body of the post.
+
+// // // // // // // //
+// In the preceding section:
+// Do not insert any blank lines between any of the lines.
+// Do not remove or edit the variables on the lines beneath the author name.
+//
+// "open-graph-image" is set to OL logo. Whenever possible update this to a more appropriate/specific image (For example if present a image that is being used in the post). However, it
+// can be left empty which will set it to the default
+//
+// "open-graph-image-alt" is a description of what is in the image (not a caption). When changing "open-graph-image" to
+// a custom picture, you must provide a custom string for "open-graph-image-alt".
+//
+// Replace TITLE with the blog post title eg: MicroProfile 3.3 is now available on Open Liberty 20.0.0.4
+// Replace GITHUB_USERNAME with your GitHub username eg: lauracowen
+// Replace DESCRIPTION with a short summary (~60 words) of the release (a more succinct version of the first paragraph of the post).
+// Replace AUTHOR_NAME with your name as you'd like it to be displayed, eg: Laura Cowen
+//
+// Example post: 2020-04-09-microprofile-3-3-open-liberty-20004.adoc
+//
+// If adding image into the post add :
+// -------------------------
+// [.img_border_light]
+// image::img/blog/FILE_NAME[IMAGE CAPTION ,width=70%,align="center"]
+// -------------------------
+// "[.img_border_light]" = This adds a faint grey border around the image to make its edges sharper. Use it around screenshots but not           
+// around diagrams. Then double check how it looks.
+// There is also a "[.img_border_dark]" class which tends to work best with screenshots that are taken on dark
+// backgrounds.
+// Change "FILE_NAME" to the name of the image file. Also make sure to put the image into the right folder which is: img/blog
+// change the "IMAGE CAPTION" to a couple words of what the image is
+// // // // // // // //
+
+Open Liberty 26.0.0.9 introduces MCP Server support (`mcp-1.0`), adds OAuth 2.0 Protected Resource Metadata support for `openidConnectClient`, and introduces custom session cache name prefixes for shared JCache clusters.
+
+// // // // // // // //
+// In the preceding section:
+// Leave any instances of `tag::xxxx[]` or `end:xxxx[]` as they are.
+//
+// Replace RELEASE_SUMMARY with a short paragraph that summarises the release. Start with the lead feature but also summarise what else is new in the release. You will agree which will be the lead feature with the reviewers so you can just leave a placeholder here until after the initial review.
+// // // // // // // //
+
+// // // // // // // //
+// Replace the following throughout the document:
+//   Replace RELEASE_VERSION with the version number of Open Liberty, eg: 22.0.0.2
+//   Replace RELEASE_VERSION_NO_PERIODS with the version number of Open Liberty wihtout the periods, eg: 22002
+// // // // // // // //
+
+In link:{url-about}[Open Liberty] 26.0.0.9:
+
+* <<mcp, MCP Server (mcp-1.0)>>
+* <<protected_resource_metadata, Protected Resource Metadata for openidConnectClient>>
+* <<session_cache_prefix, Custom session cache name prefixes for shared JCache clusters>>
+* <<CVEs, Security Vulnerability (CVE) Fixes>>
+* <<bugs, Notable bug fixes>>
+
+// // // // // // // //
+// In the preceding section:
+// Replace the TAG_X with a short label for the feature in lower-case, eg: mp3
+// Replace the FEATURE_1_HEADING with heading the feature section, eg: MicroProfile 3.3
+// Where the updates are grouped as sub-headings under a single heading 
+//   (eg all the features in a MicroProfile release), provide sub-entries in the list; 
+//   eg replace SUB_TAG_1 with mpr, and SUB_FEATURE_1_HEADING with 
+//   Easily determine HTTP headers on outgoing requests (MicroProfile Rest Client 1.4)
+// // // // // // // //
+
+View the list of fixed bugs in link:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A26009+label%3A%22release+bug%22[26.0.0.9].
+
+Check out link:{url-prefix}/blog/?search=release&search!=beta[previous Open Liberty GA release blog posts].
+
+
+[#run]
+
+// // // // // // // //
+// LINKS
+//
+// OpenLiberty.io site links:
+// link:{url-prefix}/guides/maven-intro.html[Maven]
+// 
+// Off-site links:
+//link:https://openapi-generator.tech/docs/installation#jar[Download Instructions]
+//
+// IMAGES
+//
+// Place images in ./img/blog/
+// Use the syntax:
+// image::/img/blog/log4j-rhocp-diagrams/current-problem.png[Logging problem diagram,width=70%,align="center"]
+// // // // // // // //
+
+== Develop and run your apps using 26.0.0.9
+
+If you're using link:{url-prefix}/guides/maven-intro.html[Maven], include the following in your `pom.xml` file:
+
+[source,xml]
+----
+<plugin>
+    <groupId>io.openliberty.tools</groupId>
+    <artifactId>liberty-maven-plugin</artifactId>
+    <version>3.12.3</version>
+</plugin>
+----
+
+Or for link:{url-prefix}/guides/gradle-intro.html[Gradle], include the following in your `build.gradle` file:
+
+[source,gradle]
+----
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:4.0.2'
+    }
+}
+apply plugin: 'liberty'
+----
+// // // // // // // //
+// In the preceding section:
+// Replace the Maven `3.11.5` with the latest version of the plugin: https://search.maven.org/artifact/io.openliberty.tools/liberty-maven-plugin
+// Replace the Gradle `3.9.5` with the latest version of the plugin: https://search.maven.org/artifact/io.openliberty.tools/liberty-gradle-plugin
+// TODO: Update GHA to automatically do the above.  If the maven.org is problematic, then could fallback to using the GH Releases for the plugins
+// // // // // // // //
+
+Or if you're using link:{url-prefix}/docs/latest/container-images.html[container images]:
+
+[source]
+----
+FROM icr.io/appcafe/open-liberty
+----
+
+Or take a look at our link:{url-prefix}/start/[Downloads page].
+
+If you're using link:https://plugins.jetbrains.com/plugin/14856-liberty-tools[IntelliJ IDEA], link:https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext[Visual Studio Code] or link:https://marketplace.eclipse.org/content/liberty-tools[Eclipse IDE], you can also take advantage of our open source link:https://openliberty.io/docs/latest/develop-liberty-tools.html[Liberty developer tools] to enable effective development, testing, debugging and application management all from within your IDE.
+
+[link=https://stackoverflow.com/tags/open-liberty]
+image::img/blog/blog_btn_stack.svg[Ask a question on Stack Overflow, align="center"]
+
+// // // // // // // //
+// In the preceding section:
+// Replace TAG_X/SUB_TAG_X with the given tag of your secton from the contents list
+// Replace SUB_FEATURE_TITLE/FEATURE_X_TITLE with the given title from the contents list 
+// Replace FEATURE with the feature name for the server.xml file e.g. mpHealth-1.4
+// Replace LINK with the link for extra information given for the feature
+// Replace LINK_DESCRIPTION with a readable description of the information
+// // // // // // // //
+
+[#mcp]
+== MCP Server (mcp-1.0) 
+
+The link:https://modelcontextprotocol.io/[Model Context Protocol (MCP)] is an open standard that enables AI applications to access real-time data and business logic from external sources. The MCP Server feature (`mcp-1.0`) lets application developers expose their Liberty application's tools and data for use in agentic AI workflows by using just a few annotations.
+
+Before `mcp-1.0`, there was no standard way to expose your Liberty application's existing Java business logic to AI agents. You had to build and maintain custom integrations for each AI tool you wanted to connect to. With `mcp-1.0`, you annotate your existing CDI methods with `@Tool` and Liberty automatically handles the MCP protocol, tool discovery, session management, security, and observability. Your application becomes immediately usable by any MCP-compatible AI agent without changing your business logic.
+
+=== What's new in 26.0.0.9
+
+After several beta releases, `mcp-1.0` is now generally available. The most important change since the last beta (`26.0.0.9-beta`) is that the feature name changed from `mcpServer-1.0` to `mcp-1.0`, and the `server.xml` configuration element changed from `<mcpServer>` to `<mcp>`. Update your `server.xml` as follows:
+
+[source,xml]
+----
+<featureManager>
+    <feature>mcp-1.0</feature>
+</featureManager>
+<application location="my-app.war">
+    <mcp path="/custom-mcp"/>
+</application>
+----
+
+If you are migrating from 26.0.0.8-beta or earlier, the core API types also moved from `io.openliberty.mcp.*` to `org.mcpjava.server.*`. For full details on those import changes, see the link:{url-prefix}/blog/2026/08/25/26.0.0.9-beta.html[26.0.0.9-beta blog post].
+
+The following capabilities are also new in this GA release and were not included in 26.0.0.9-beta:
+
+* *DNS rebinding attack protection* — When an MCP server receives a request from a loopback address, it now validates the `Origin` header as required by the MCP specification. No configuration needed.
+* *`@MetaField` support on tool methods* — Tool methods can be annotated with `@MetaField` to add data to the `_meta` object in `tools/list` responses.
+* *`outputSchemaFrom` on `@Tool`* — When `structuredContent = true`, you can specify a different class for generating the output schema, independent of the method return type.
+* *Warnings for unsupported annotations* — If your application uses MCP Java API annotations that are not supported by `mcp-1.0` (such as `@Prompt`, `@Resource`, `@ResourceTemplate`), Liberty now logs a warning. The application still starts and `@Tool`-annotated methods continue to work.
+* *OAuth 2.0 Protected Resource Metadata (RFC 9720)* — When `protectedResourceMetaDataEnabled="true"` is configured on `openidConnectClient`, Liberty serves the protected resource metadata document at `/.well-known/oauth-protected-resource`. This enables MCP clients to automatically discover the correct authorization server following the MCP authorization flow.
+
+For a full getting-started guide and examples, see the link:{url-prefix}/blog/2026/08/25/26.0.0.9-beta.html[Expose your Liberty business logic as AI tools blog post] and the link:{url-prefix}/docs/latest/reference/feature/mcp-1.0.html[mcp-1.0 feature documentation].
+
+[#protected_resource_metadata]
+== Protected Resource Metadata for openidConnectClient
+
+OAuth 2.0 Protected Resource Metadata (RFC 9720) provides metadata about an OAuth 2.0-protected resource, including a link to the authorization server that can grant access.
+
+In this release, Open Liberty servers that use the `openidConnectClient-1.0` feature can enable protected resource metadata. Protected resource metadata can be enabled for any         `openidConnectClient` configuration, but the primary use case is with the `mcp-1.0` feature to support the MCP authorization flow. In this flow, the MCP client uses the protected resource metadata to discover the authorization server.
+
+To enable protected resource metadata for an `openidConnectClient` configuration, add the `<protectedResourceMetadata>` configuration element:
+
+[source,xml]
+----
+<openidConnectClient id="protected-resource-demo"
+    clientId="protected-resource"
+    clientSecret="..."
+    jwkEndpointUrl="https://auth.example.com/oidc/endpoint/SampleProvider/jwk"
+    tokenEndpointAuthMethod="basic"
+    issuerIdentifier="https://auth.example.com/oidc/endpoint/SampleProvider"
+    authFilterRef="mcpAuthFilter"
+    inboundPropagation="required">
+    <protectedResourceMetadata />
+</openidConnectClient>
+----
+
+For more information, see the link:{url-prefix}/docs/latest/reference/feature/openidConnectClient-1.0.html[OpenID Connect Client feature documentation] and the link:{url-prefix}/docs/latest/reference/config/openidConnectClient.html[openidConnectClient configuration reference].
+
+
+[#session_cache_prefix]
+== Custom session cache name prefixes for shared JCache clusters
+
+When you run multiple Liberty instances that share the same JCache-based session store — for example, several pods on Kubernetes or OpenShift pointing at the same Hazelcast or Infinispan cluster — Liberty previously generated identical session cache names on every instance. Identical cache names meant that separate instances could collide on the same cache, risking session data corruption in shared cache deployments.
+
+Open Liberty 26.0.0.9 adds the new `cacheNamePrefix` attribute to the `httpSessionCache` element in the `sessionCache-1.0` feature.The attribute is intended for operations teams and administrators who run multi-instance Liberty deployments backed by a shared cache cluster. Use it when each instance requires distinct cache namespacing to avoid collisions.
+
+Previously, Liberty always generated session cache names as `com.ibm.ws.session.meta.*` and `com.ibm.ws.session.attr.*`, with no way to distinguish which Liberty instance created them. Now, you can configure each instance with its own prefix, so the same shared cluster can safely host session data from multiple Liberty servers without cache name collisions. If no prefix is configured, the feature is fully backward compatible.
+
+To configure a cache name prefix, add the `cacheNamePrefix ` attribute to your `httpSessionCache` configuration:
+
+[source,xml]
+----
+<!-- Instance 1 -->
+<httpSessionCache cacheRef="InfinispanCacheManager" cacheNamePrefix="pod1_"/>
+<!-- Instance 2 -->
+<httpSessionCache cacheRef="InfinispanCacheManager" cacheNamePrefix="pod2_"/>
+----
+
+The prefixes result in distinct cache names for each instance — `pod1_com.ibm.ws.session.attr.default_host/myapp` and `pod2_com.ibm.ws.session.attr.default_host/myapp`. Without a prefix, both instances would generate the same `com.ibm.ws.session.attr.default_host/myapp` cache name. The `cacheNamePrefix` attribute is especially useful for:
+
+* Multi-tenant deployments
+* Blue-green deployments needing separate cache namespaces
+* Kubernetes/OpenShift deployments requiring pod-specific cache isolation
+
+For more information about configuring session caching, see the link:{url-prefix}/docs/latest/reference/config/httpSessionCache.html[httpSessionCache reference] documentation.
+
+[#CVEs]
+== Security vulnerability (CVE) fixes in this release
+[cols="5*"]
+|===
+|CVE |CVSS Score |Vulnerability Assessment |Versions Affected |Notes
+
+|https://www.cve.org/CVERecord?id=CVE-2026-14529[CVE-2026-14529]
+|9.4
+|Server-side request forgery
+|17.0.0.3-26.0.0.8
+|Affects the `sipServlet-1.1` feature
+
+|https://www.cve.org/CVERecord?id=CVE-2026-14981[CVE-2026-14981]
+|7.5
+|Denial of service
+|17.0.0.3-26.0.0.8
+|Affects the `servlet-3.1`, `servlet-4.0`, `servlet-5.0`, `servlet-6.0`, and `servlet-6.1` features
+
+|https://www.cve.org/CVERecord?id=CVE-2026-15064[CVE-2026-15064]
+|8.7
+|HTTP response smuggling
+|17.0.0.3-26.0.0.8
+|Affects the `servlet-3.1`, `servlet-4.0`, `servlet-5.0`, `servlet-6.0`, and `servlet-6.1` features
+
+|https://www.cve.org/CVERecord?id=CVE-2026-15328[CVE-2026-15328]
+|7.4
+|HTTP request smuggling
+|17.0.0.3-26.0.0.8
+|Affects the `servlet-3.1`, `servlet-4.0`, `servlet-5.0`, `servlet-6.0`, and `servlet-6.1` features
+
+|https://www.cve.org/CVERecord?id=CVE-2026-15325[CVE-2026-15325]
+|8.7
+|HTTP request smuggling
+|17.0.0.3-26.0.0.8
+|Affects the `servlet-3.1`, `servlet-4.0`, `servlet-5.0`, `servlet-6.0`, and `servlet-6.1` features
+
+|https://www.cve.org/CVERecord?id=CVE-2026-16192[CVE-2026-16192]
+|7.1
+|Denial of service
+|17.0.0.3-26.0.0.8
+|Affects the `restConnector-2.0` feature
+
+|https://www.cve.org/CVERecord?id=CVE-2026-10571[CVE-2026-10571]
+|5.7
+|Denial of service
+|17.0.0.3-26.0.0.8
+|Affects the `restConnector-2.0` feature
+
+|https://www.cve.org/CVERecord?id=CVE-2026-54225[CVE-2026-54225]
+|7.5
+|Denial of service
+|17.0.0.3-26.0.0.8
+|Affects the `jaxrs-2.0`, `jaxrs-2.1`, `jaxws-2.2`, `xmlWS-3.0`, and `xmlWS-4.0` features
+
+|https://www.cve.org/CVERecord?id=CVE-2026-57819[CVE-2026-57819]
+|7.5
+|Denial of service
+|17.0.0.3-26.0.0.8
+|Affects the `jaxrs-2.0`, `jaxrs-2.1`, `jaxws-2.2`, `xmlWS-3.0`, and `xmlWS-4.0` features
+
+|https://www.cve.org/CVERecord?id=CVE-2026-64958[CVE-2026-64958]
+|7.5
+|Denial of service
+|17.0.0.3-26.0.0.8
+|Affects the `jaxrs-2.0`, `jaxrs-2.1`, `jaxws-2.2`, `xmlWS-3.0`, and `xmlWS-4.0` features
+
+|===
+// // // // // // // //
+// In the preceding section:
+// If there were any CVEs addressed in this release, fill out the table.  For the information, reference https://github.com/OpenLiberty/docs/blob/draft/modules/ROOT/pages/security-vulnerabilities.adoc.  If it has not been updated for this release, reach out to Kristen Clarke or Michal Broz.
+// Note: When linking to features, use the 
+// `link:{url-prefix}/docs/latest/reference/feature/someFeature-1.0.html[Some Feature 1.0]` format and 
+// NOT what security-vulnerabilities.adoc does (feature:someFeature-1.0[])
+//
+// If there are no CVEs fixed in this release, replace the table with: 
+// "There are no security vulnerability fixes in Open Liberty 26.0.0.9."
+// // // // // // // //
+For a list of past security vulnerability fixes, reference the link:{url-prefix}/docs/latest/security-vulnerabilities.html[Security vulnerability (CVE) list].
+
+
+[#bugs]
+== Notable bugs fixed in this release
+
+
+We've spent some time fixing bugs. The following sections describe just some of the issues resolved in this release. If you're interested, here's the  link:https://github.com/OpenLiberty/open-liberty/issues?q=label%3Arelease%3A26009+label%3A%22release+bug%22[full list of bugs fixed in 26.0.0.9].
+
+* link:https://github.com/OpenLiberty/open-liberty/issues/35587[Cannot invoke "jakarta.interceptor.InvocationContext.getParameters()" because "this.firstInvocation" is null]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35567[IBM WebSphere Application Server Liberty is affected by a privilege escalation when using Liberty collectives (CVE-2026-18499)]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35555[HTTP channel parser improvements for handling header and body framing]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35545[IBM WebSphere Application Server Liberty is affected by a denial of service vulnerability (CVE-2026-10571)]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35541[IBM WebSphere Application Server Liberty is affected by Denial of Service vulnerabilities (CVE-2026-57819, CVE-2026-54225, CVE-2026-64958)]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35489[z/OS ICH408I SAF EJBROLE lookup triggered for unauthenticated JAX-RS requests due to null principal passed to isUserInRole]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35473[Jakarta Security 4.0 (appSecurity-6.0) HAM processing fails when deployed using mvn liberty:dev]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35471[IBM WebSphere Application Server is affected by multiple vulnerabilities (CVE-2026-14980, CVE-2026-2482)]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35469[IBM WebSphere Application Server Liberty is affected by a denial of service vulnerability when the restConnector-2.0 feature is enabled (CVE-2026-16192)]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35424[Invocation.Builder.property() settings ignored by HTTP transport for set.content.type.for.empty.request]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35361[IBM WebSphere Application Server Liberty is affected by multiple vulnerabilities (CVE-2026-15328, CVE-2026-15064, CVE-2026-15325, CVE-2026-14981)]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35355[Throughput performance degradation due to enabling logged out cookie cache]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35345[pluginUtility merge fails when encountering an "improperly scoped subset"]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35332[Graceful Startup Issue - liberty-kafka connector: @Incoming methods receive messages before application startup completes — causes permanent channel death]
+* link:https://github.com/OpenLiberty/open-liberty/issues/35022[EclipseLink bug comparing boolean value in H2]
+* link:https://github.com/OpenLiberty/open-liberty/issues/34313[maxParamPerRequest is not honoring the maximum configured number]
+
+// // // // // // // //
+// In the preceding section:
+// For this section ask either Michal Broz or Tom Evans or the #openliberty-release-blog channel for Notable bug fixes in this release.
+// Present them as a list in the order as provided, linking to the issue and providing a short description of the bug and the resolution.
+// If the issue on Github is missing any information, leave a comment in the issue along the lines of:
+// "@[issue_owner(s)] please update the description of this `release bug` using the [bug report template](https://github.com/OpenLiberty/open-liberty/issues/new?assignees=&labels=release+bug&template=bug_report.md&title=)" 
+// Feel free to message the owner(s) directly as well, especially if no action has been taken by them.
+// For inspiration about how to write this section look at previous blogs e.g- 20.0.0.10 or 21.0.0.12 (https://openliberty.io/blog/2021/11/26/jakarta-ee-9.1.html#bugs)
+// // // // // // // //
+
+
+== Get Open Liberty 26.0.0.9 now
+
+Available through <<run,Maven, Gradle, Docker, and as a downloadable archive>>.

--- a/posts/2026-09-08-26.0.0.9.adoc
+++ b/posts/2026-09-08-26.0.0.9.adoc
@@ -193,7 +193,7 @@ The following capabilities are also new in this GA release and were not included
 * *Warnings for unsupported annotations* — If your application uses MCP Java API annotations that are not supported by `mcp-1.0` (such as `@Prompt`, `@Resource`, `@ResourceTemplate`), Liberty now logs a warning. The application still starts and `@Tool`-annotated methods continue to work.
 * *OAuth 2.0 Protected Resource Metadata (RFC 9720)* — When `protectedResourceMetaDataEnabled="true"` is configured on `openidConnectClient`, Liberty serves the protected resource metadata document at `/.well-known/oauth-protected-resource`. This enables MCP clients to automatically discover the correct authorization server following the MCP authorization flow.
 
-For a full getting-started guide and examples, see the link:{url-prefix}/blog/2026/08/25/26.0.0.9-beta.html[Expose your Liberty business logic as AI tools blog post] and the link:{url-prefix}/docs/latest/reference/feature/mcp-1.0.html[mcp-1.0 feature documentation].
+For a full getting-started guide and examples, see the link:{url-prefix}/blog/2026/08/25/26.0.0.9-beta.html[Expose your Liberty business logic as AI tools blog post] and the link:{url-prefix}/docs/latest/liberty-mcp-server.html[mcp-1.0 feature documentation].
 
 [#protected_resource_metadata]
 == Protected Resource Metadata for openidConnectClient

--- a/posts/2026-09-08-26.0.0.9.adoc
+++ b/posts/2026-09-08-26.0.0.9.adoc
@@ -193,7 +193,7 @@ The following capabilities are also new in this GA release and were not included
 * *Warnings for unsupported annotations* — If your application uses MCP Java API annotations that are not supported by `mcp-1.0` (such as `@Prompt`, `@Resource`, `@ResourceTemplate`), Liberty now logs a warning. The application still starts and `@Tool`-annotated methods continue to work.
 * *OAuth 2.0 Protected Resource Metadata (RFC 9720)* — When `protectedResourceMetaDataEnabled="true"` is configured on `openidConnectClient`, Liberty serves the protected resource metadata document at `/.well-known/oauth-protected-resource`. This enables MCP clients to automatically discover the correct authorization server following the MCP authorization flow.
 
-For a full getting-started guide and examples, see the link:{url-prefix}/blog/2026/08/25/26.0.0.9-beta.html[Expose your Liberty business logic as AI tools blog post] and the link:{url-prefix}/docs/latest/liberty-mcp-server.html[mcp-1.0 feature documentation].
+For a full getting-started guide and examples, see the link:{url-prefix}/blog/2026/08/25/mcp-tools.html[Expose your Liberty business logic as AI tools blog post] and the link:{url-prefix}/docs/latest/liberty-mcp-server.html[mcp-1.0 feature documentation].
 
 [#protected_resource_metadata]
 == Protected Resource Metadata for openidConnectClient

--- a/posts/2026-09-08-26.0.0.9.adoc
+++ b/posts/2026-09-08-26.0.0.9.adoc
@@ -169,6 +169,8 @@ The link:https://modelcontextprotocol.io/[Model Context Protocol (MCP)] is an op
 
 Before `mcp-1.0`, there was no standard way to expose your Liberty application's existing Java business logic to AI agents. You had to build and maintain custom integrations for each AI tool you wanted to connect to. With `mcp-1.0`, you annotate your existing CDI methods with `@Tool` and Liberty automatically handles the MCP protocol, tool discovery, session management, security, and observability. Your application becomes immediately usable by any MCP-compatible AI agent without changing your business logic.
 
+For a full getting-started guide and examples, see the link:{url-prefix}/blog/2026/08/25/mcp-tools.html[Expose your Liberty business logic as AI tools blog post] and the link:{url-prefix}/docs/latest/liberty-mcp-server.html[mcp-1.0 feature documentation].
+
 === What's new in 26.0.0.9
 
 After several beta releases, `mcp-1.0` is now generally available. The most important change since the last beta (`26.0.0.9-beta`) is that the feature name changed from `mcpServer-1.0` to `mcp-1.0`, and the `server.xml` configuration element changed from `<mcpServer>` to `<mcp>`. Update your `server.xml` as follows:
@@ -192,8 +194,6 @@ The following capabilities are also new in this GA release and were not included
 * *`outputSchemaFrom` on `@Tool`* — When `structuredContent = true`, you can specify a different class for generating the output schema, independent of the method return type.
 * *Warnings for unsupported annotations* — If your application uses MCP Java API annotations that are not supported by `mcp-1.0` (such as `@Prompt`, `@Resource`, `@ResourceTemplate`), Liberty now logs a warning. The application still starts and `@Tool`-annotated methods continue to work.
 * *OAuth 2.0 Protected Resource Metadata (RFC 9720)* — When `protectedResourceMetaDataEnabled="true"` is configured on `openidConnectClient`, Liberty serves the protected resource metadata document at `/.well-known/oauth-protected-resource`. This enables MCP clients to automatically discover the correct authorization server following the MCP authorization flow.
-
-For a full getting-started guide and examples, see the link:{url-prefix}/blog/2026/08/25/26.0.0.9-beta.html[Expose your Liberty business logic as AI tools blog post] and the link:{url-prefix}/docs/latest/liberty-mcp-server.html[mcp-1.0 feature documentation].
 
 [#protected_resource_metadata]
 == Protected Resource Metadata for openidConnectClient
@@ -226,11 +226,11 @@ For more information, see the link:{url-prefix}/docs/latest/reference/feature/op
 
 When you run multiple Liberty instances that share the same JCache-based session store — for example, several pods on Kubernetes or OpenShift pointing at the same Hazelcast or Infinispan cluster — Liberty previously generated identical session cache names on every instance. Identical cache names meant that separate instances could collide on the same cache, risking session data corruption in shared cache deployments.
 
-Open Liberty 26.0.0.9 adds the new `cacheNamePrefix` attribute to the `httpSessionCache` element in the `sessionCache-1.0` feature.The attribute is intended for operations teams and administrators who run multi-instance Liberty deployments backed by a shared cache cluster. Use it when each instance requires distinct cache namespacing to avoid collisions.
+Open Liberty 26.0.0.9 adds the new `cacheNamePrefix` attribute to the `httpSessionCache` element in the `sessionCache-1.0` feature. The attribute is intended for operations teams and administrators who run multi-instance Liberty deployments backed by a shared cache cluster. Use it when each instance requires distinct cache namespacing to avoid collisions.
 
-Previously, Liberty always generated session cache names as `com.ibm.ws.session.meta.*` and `com.ibm.ws.session.attr.*`, with no way to distinguish which Liberty instance created them. Now, you can configure each instance with its own prefix, so the same shared cluster can safely host session data from multiple Liberty servers without cache name collisions. If no prefix is configured, the feature is fully backward compatible.
+Previously, Liberty always generated session cache names as `com.ibm.ws.session.meta.XXX` or `com.ibm.ws.session.attr.XXX`, with no way to distinguish which Liberty server created them. Now, you can configure each Liberty server with its unique prefix. This means that a single shared cluster can safely host session data from multiple Liberty servers, without namespace collisions. If no prefix is configured, the original cache names will still be used.
 
-To configure a cache name prefix, add the `cacheNamePrefix ` attribute to your `httpSessionCache` configuration:
+To configure a cache name prefix, add the `cacheNamePrefix` attribute to your `httpSessionCache` configuration:
 
 [source,xml]
 ----

--- a/posts/2026-09-08-26.0.0.9.adoc
+++ b/posts/2026-09-08-26.0.0.9.adoc
@@ -226,7 +226,7 @@ For more information, see the link:{url-prefix}/docs/latest/reference/feature/op
 
 When you run multiple Liberty instances that share the same JCache-based session store — for example, several pods on Kubernetes or OpenShift pointing at the same Hazelcast or Infinispan cluster — Liberty previously generated identical session cache names on every instance. Identical cache names meant that separate instances could collide on the same cache, risking session data corruption in shared cache deployments.
 
-Open Liberty 26.0.0.9 adds the new `cacheNamePrefix` attribute to the `httpSessionCache` element in the `sessionCache-1.0` feature.The attribute is intended for operations teams and administrators who run multi-instance Liberty deployments backed by a shared cache cluster. Use it when each instance requires distinct cache namespacing to avoid collisions.
+Open Liberty 26.0.0.9 adds the new `cacheNamePrefix` attribute to the `httpSessionCache` element in the `sessionCache-1.0` feature. The attribute is intended for operations teams and administrators who run multi-instance Liberty deployments backed by a shared cache cluster. Use it when each instance requires distinct cache namespacing to avoid collisions.
 
 Previously, Liberty always generated session cache names as `com.ibm.ws.session.meta.*` and `com.ibm.ws.session.attr.*`, with no way to distinguish which Liberty instance created them. Now, you can configure each instance with its own prefix, so the same shared cluster can safely host session data from multiple Liberty servers without cache name collisions. If no prefix is configured, the feature is fully backward compatible.
 


### PR DESCRIPTION
Staging site : https://blogs-staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/blog/2026/09/08/26.0.0.9.html


Corresponding Blog issues:
[GA BLOG - Protected Resource Metadata for openidConnectClient #35632](https://github.com/OpenLiberty/open-liberty/issues/35632) 
[GA BLOG -MCP Server (mcp-1.0) is now GA in Open Liberty 26.0.0.9 #35641](https://github.com/OpenLiberty/open-liberty/issues/35641)
[GA BLOG - Custom session cache name prefixes for shared JCache clusters #35607](https://github.com/OpenLiberty/open-liberty/issues/35607)